### PR TITLE
Make Javadoc comments JDK8 compliant

### DIFF
--- a/Java/Eta/Applications/Examples/com/thomsonreuters/upa/examples/common/ProviderLoginHandler.java
+++ b/Java/Eta/Applications/Examples/com/thomsonreuters/upa/examples/common/ProviderLoginHandler.java
@@ -224,7 +224,7 @@ public class ProviderLoginHandler
      * @param chnl - The channel to send close status message to
      * @param error - Error information in case of failure
      * @return {@link CodecReturnCodes#SUCCESS} if close status message sent
-     *         successfully, < {@link CodecReturnCodes#SUCCESS} when it fails.
+     *         successfully, &lt; {@link CodecReturnCodes#SUCCESS} when it fails.
      */
     public int sendCloseStatus(Channel chnl, Error error)
     {

--- a/Java/Eta/Applications/Examples/com/thomsonreuters/upa/examples/common/StreamIdWatchList.java
+++ b/Java/Eta/Applications/Examples/com/thomsonreuters/upa/examples/common/StreamIdWatchList.java
@@ -14,7 +14,7 @@ import com.thomsonreuters.upa.rdm.DomainTypes;
 
 /**
  * This is a hash map based WatchList for quick lookup of item states when
- * response is received. It is a map of (stream id -> item states). Initial
+ * response is received. It is a map of (stream id -&gt; item states). Initial
  * state for a stream when request is sent is unspecified. State is updated with
  * state from status and refresh message.
  */

--- a/Java/Eta/Applications/Examples/com/thomsonreuters/upa/examples/niprovider/StreamIdWatchList.java
+++ b/Java/Eta/Applications/Examples/com/thomsonreuters/upa/examples/niprovider/StreamIdWatchList.java
@@ -14,7 +14,7 @@ import com.thomsonreuters.upa.rdm.DomainTypes;
 /**
  * This is a hash map based WatchList for quick lookup of items and their
  * associated streamId and domainType when sending updates or reissuing
- * refreshes. It is a map of (streamId -> item info).
+ * refreshes. It is a map of (streamId -&gt; item info).
  */
 public class StreamIdWatchList implements Iterable<Map.Entry<Integer, WatchListEntry>>
 {

--- a/Java/Eta/Applications/Examples/com/thomsonreuters/upa/valueadd/examples/consumer/Consumer.java
+++ b/Java/Eta/Applications/Examples/com/thomsonreuters/upa/valueadd/examples/consumer/Consumer.java
@@ -138,11 +138,10 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorRole;
  * <p> 
  * java -cp ./bin;../../Libs/upa.jar;../../Libs/upaValueAdd.jar;../../Libs/upaValueAddCache.jar
  * com.thomsonreuters.upa.valueadd.examples.consumer.Consumer
- * [-c &lthostname&gt:&ltport&gt &ltservice name&gt &ltdomain&gt:&ltitem name&gt,...]
- * [-uname &ltLoginUsername&gt] [-view] [-post] [-offpost]  [-publisherInfo &ltuserId,address&gt] [-snapshot] [-runtime &ltseconds&gt]
- * [-cache] [-cacheInterval &ltseconds&gt]
+ * [-c &lt;hostname&gt;:&lt;port&gt; &lt;service name&gt; &lt;domain&gt;:&lt;item name&gt;,...]
+ * [-uname &lt;LoginUsername&gt;] [-view] [-post] [-offpost]  [-publisherInfo &lt;userId,address&gt;] [-snapshot] [-runtime &lt;seconds&gt;]
+ * [-cache] [-cacheInterval &lt;seconds&gt;]
  * </p>
- * <p>
  * <ul>
  * <li>-c specifies a connection to open and a list of items to request:
  * <ul>
@@ -205,7 +204,6 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorRole;
  * <li>-keypasswd keystore password for encryption.
  * 
  * </ul>
- * </p>
  */
 public class Consumer implements ConsumerCallback
 {

--- a/Java/Eta/Applications/Examples/com/thomsonreuters/upa/valueadd/examples/niprovider/NIProvider.java
+++ b/Java/Eta/Applications/Examples/com/thomsonreuters/upa/valueadd/examples/niprovider/NIProvider.java
@@ -58,7 +58,6 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorRole;
  * client application using ValueAdd components.
  * </p>
  * <H2>Summary</H2>
- * <p>
  * This class is responsible for the following:
  * <ul>
  * <li>Initialize and set command line options.
@@ -67,7 +66,6 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorRole;
  * Directory, Dictionary and default message callbacks.
  * <li>Connect to the ADH provider, send item refreshes, then send item updates.
  * </ul>
- * </p>
  * <p>
  * This class is also a call back for all events from Consumer/ADH. It
  * dispatches events to domain specific handlers.
@@ -100,10 +98,9 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorRole;
  * <p> 
  * java -cp ./bin;../../Libs/upa.jar;../../Libs/upaValueAdd.jar;../../Libs/upaValueAddCache.jar
  * com.thomsonreuters.upa.valueadd.examples.niprovider.NIProvider
- * [-c &lthostname&gt:&ltport&gt &ltservice &gt &ltdomain&gt:&ltitem name&gt,...]
- * [-uname &ltLoginUsername&gt] [-runtime &ltseconds&gt] [-bc &ltbackup hostname&gt:&lt backup port&gt]
+ * [-c &lt;hostname&gt;:&lt;port&gt; &lt;service &gt; &lt;domain&gt;:&lt;item name&gt;,...]
+ * [-uname &lt;LoginUsername&gt;] [-runtime &lt;seconds&gt;] [-bc &lt;backup hostname&gt;:&lt; backup port&gt;]
  * </p>
- * <p>
  * <ul>
  * <li>-c specifies a tcp connection to open and a list of items to provide:
  * <ul>
@@ -119,17 +116,15 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorRole;
  *  <li>backup port:     Backup port of ADH to connect to
  *  </ul>
  * </ul>
- * </p>
  * <p>
  * Tcp primary connection and Tcp backup connection can be replaced by reliable multicast primary and backup multicast connections. 
  * </p>
  * <p> 
  * java -cp ./obj;../../Libs/upa.jar;../Libs/upaValueAdd.jar;../Libs/upaValueAddCache.jar
  * com.thomsonreuters.upa.valueadd.examples.niprovider.NIProvider
- * [-segmentedMulticast &ltsa&gt:&ltsp&gt:&ltif&gt &ltra&gt:&ltrp&gt &ltup&gt &ltservice &gt &ltdomain&gt:&ltitem name&gt,...]
- * [-uname &ltLoginUsername&gt] [-runtime &ltseconds&gt] [-mbc &ltbsa&gt:&ltbsp&gt:&ltbif&gt &ltbra&gt:&ltbrp&gt &ltbup&gt] [-cache]
+ * [-segmentedMulticast &lt;sa&gt;:&lt;sp&gt;:&lt;if&gt; &lt;ra&gt;:&lt;rp&gt; &lt;up&gt; &lt;service &gt; &lt;domain&gt;:&lt;item name&gt;,...]
+ * [-uname &lt;LoginUsername&gt;] [-runtime &lt;seconds&gt;] [-mbc &lt;bsa&gt;:&lt;bsp&gt;:&lt;bif&gt; &lt;bra&gt;:&lt;brp&gt; &lt;bup&gt;] [-cache]
  * </p>
- * <p>
  * <ul>
  * <li>-segmentedMulticast specifies a reliable multicast connection to open and a list of items to provide:
  * <ul>
@@ -153,7 +148,6 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorRole;
  *  <li>bup:     Backup unicast port of ADH to connect to  
  *  </ul>
  * </ul>
- * </p>
  * <ul>
  * <li>-uname Login user name. Default is system user name.
  * <li>-x. Provides XML tracing of messages.

--- a/Java/Eta/Applications/Examples/com/thomsonreuters/upa/valueadd/examples/provider/Provider.java
+++ b/Java/Eta/Applications/Examples/com/thomsonreuters/upa/valueadd/examples/provider/Provider.java
@@ -116,10 +116,9 @@ import com.thomsonreuters.upa.valueadd.reactor.TunnelStreamRequestEvent;
  * </p>
  * <p>
  * java -cp ./bin;../../Libs/upa.jar;../../Libs/upaValueAdd.jar;../../Libs/upaValueAddCache.jar
- * com.thomsonreuters.upa.valueadd.examples.provider.Provider [-p &ltport number&gt]
- * [-i &ltinterface name&gt] [-s &ltservice name&gt] [-id &ltservice ID&gt] [-cache] [-runtime &ltseconds&gt]
+ * com.thomsonreuters.upa.valueadd.examples.provider.Provider [-p &lt;port number&gt;]
+ * [-i &lt;interface name&gt;] [-s &lt;service name&gt;] [-id &lt;service ID&gt;] [-cache] [-runtime &lt;seconds&gt;]
  * </p>
- * <p>
  * <ul>
  * <li>-p server port number (defaults to 14002)
  * <li>-i interface name (defaults to null)
@@ -129,7 +128,6 @@ import com.thomsonreuters.upa.valueadd.reactor.TunnelStreamRequestEvent;
  * <li>-cache application supports apply/retrieve data to/from cache
  * <li>-runtime application runtime in seconds (default is 1200)
  * </ul>
- * </p>
  */
 public class Provider implements ProviderCallback, TunnelStreamListenerCallback
 {

--- a/Java/Eta/Applications/Examples/com/thomsonreuters/upa/valueadd/examples/queueconsumer/QueueConsumer.java
+++ b/Java/Eta/Applications/Examples/com/thomsonreuters/upa/valueadd/examples/queueconsumer/QueueConsumer.java
@@ -74,9 +74,8 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorRole;
  * <p> 
  * java -cp ./bin;../../Libs/upa.jar;../../Libs/upaValueAdd.jar
  * com.thomsonreuters.upa.valueadd.examples.queueconsumer.QueueConsumer
- * [-c &lthostname&gt:&ltport&gt ]
+ * [-c &lt;hostname&gt;:&lt;port&gt; ]
  * </p>
- * <p>
  * <ul>
  * <li>-c specifies a connection to open:
  * <ul>
@@ -103,7 +102,6 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorRole;
  * <li>-tsDomain (optional) specifies the domain that consumer will use when opening the tunnel stream.
  * 
  * </ul>
- * </p>
  */
 public class QueueConsumer implements ConsumerCallback
 {    

--- a/Java/Eta/Applications/Examples/com/thomsonreuters/upa/valueadd/examples/watchlistconsumer/WatchlistConsumer.java
+++ b/Java/Eta/Applications/Examples/com/thomsonreuters/upa/valueadd/examples/watchlistconsumer/WatchlistConsumer.java
@@ -85,7 +85,7 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorSubmitOptions;
  * the default callback for processing RsslMsgs. The main function
  * Initializes the UPA Reactor, makes the desired connections, and
  * dispatches for events.
- * This application makes use of the RDM package for easier decoding of Login & Source Directory
+ * This application makes use of the RDM package for easier decoding of Login &amp; Source Directory
  * messages.
  * </p>
  * <p>
@@ -143,7 +143,6 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorSubmitOptions;
  * [-krbfile proxyKRBFile] [-keyfile keystoreFile] [-keypasswd keystore password]
  * [-tunnel] [-tsDomain domain] [-tsAuth] [-qSourceName name] [-qDestName name] [-tsServiceName name]
  *   
- * <p>
  * <ul>
  * <li>-h Server host name. Default is <i>localhost</i>.
  * <li>-p Server port number. Default is <i>14002</i>.
@@ -200,7 +199,6 @@ import com.thomsonreuters.upa.valueadd.reactor.ReactorSubmitOptions;
  * <li>-tsAuth (optional) specifies that consumer will request authentication when opening the tunnel stream. This applies to basic tunnel streams and those opened for queue messaging.
  * <li>-tsDomain (optional) specifies the domain that consumer will use when opening the tunnel stream. This applies to basic tunnel streams and those opened for queue messaging.
  * </ul>
- * </p>
  */
 public class WatchlistConsumer implements ConsumerCallback
 {

--- a/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/DictionaryProvider.java
+++ b/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/DictionaryProvider.java
@@ -130,7 +130,7 @@ public class DictionaryProvider
      * @param dIter - The decode iterator
      * @param error - Error information in case of failure
      * @return {@link PerfToolsReturnCodes#SUCCESS} for successful request
-     *         processing, < {@link PerfToolsReturnCodes#SUCCESS} when request
+     *         processing, &lt; {@link PerfToolsReturnCodes#SUCCESS} when request
      */
     public int processMsg(ChannelHandler channelHandler, ClientChannelInfo clientChannelInfo, Msg msg, DecodeIterator dIter, Error error)
     {

--- a/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/ItemEncoder.java
+++ b/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/ItemEncoder.java
@@ -54,8 +54,8 @@ public class ItemEncoder
 	 * @param itemInfo - market data item to encode post message for.
 	 * @param msgBuf  - TransportBuffer to encode post message into.
 	 * @param postUserInfo 
-	 * @param encodeStartTime - if >0, this is a latency timestamp to be included in the post message.
-	 * @return <0 if encoding fails, 0 otherwise.
+	 * @param encodeStartTime - if &gt;0, this is a latency timestamp to be included in the post message.
+	 * @return &lt;0 if encoding fails, 0 otherwise.
 	 */
 	public int encodeItemPost(Channel channel, ItemInfo itemInfo, TransportBuffer msgBuf, PostUserInfo postUserInfo, long encodeStartTime)
 	{
@@ -124,8 +124,8 @@ public class ItemEncoder
      * @param postMsg - PostMsg to create post message into.
      * @param postBuffer - buffer for UpdateMsg in encoded data body.
      * @param postUserInfo 
-     * @param encodeStartTime - if >0, this is a latency timestamp to be included in the post message.
-     * @return <0 if encoding fails, 0 otherwise.
+     * @param encodeStartTime - if &gt;0, this is a latency timestamp to be included in the post message.
+     * @return &lt;0 if encoding fails, 0 otherwise.
      */
     public int createItemPost(Channel channel, ItemInfo itemInfo, PostMsg postMsg, Buffer postBuffer, PostUserInfo postUserInfo, long encodeStartTime)
     {
@@ -186,8 +186,8 @@ public class ItemEncoder
 	 * @param channel - channel to encode generic message for.
 	 * @param itemInfo - market data item to encode generic message for.
 	 * @param msgBuf  - TransportBuffer to encode generic message into.
-	 * @param encodeStartTime - if >0, this is a latency timestamp to be included in the generic message.
-	 * @return <0 if encoding fails, 0 otherwise.
+	 * @param encodeStartTime - if &gt;0, this is a latency timestamp to be included in the generic message.
+	 * @return &lt;0 if encoding fails, 0 otherwise.
 	 */
 	public int encodeItemGenMsg(Channel channel, ItemInfo itemInfo, TransportBuffer msgBuf, long encodeStartTime)
 	{
@@ -237,8 +237,8 @@ public class ItemEncoder
      * @param itemInfo - market data item to encode generic message for.
      * @param genericMsg - GenericMsg to create post message into.
      * @param genericBuffer - buffer for UpdateMsg in encoded data body.
-     * @param encodeStartTime - if >0, this is a latency timestamp to be included in the generic message.
-     * @return <0 if encoding fails, 0 otherwise.
+     * @param encodeStartTime - if &gt;0, this is a latency timestamp to be included in the generic message.
+     * @return &lt;0 if encoding fails, 0 otherwise.
      */
     public int createItemGenMsg(Channel channel, ItemInfo itemInfo, GenericMsg genericMsg, Buffer genericBuffer, long encodeStartTime)
     {
@@ -390,9 +390,9 @@ public class ItemEncoder
      * @param itemInfo - market data item to encode update message for.
      * @param msgBuf  - TransportBuffer to encode update message into.
      * @param postUserInfo 
-     * @param encodeStartTime - if >0, this is a latency timestamp to be included in the update message.
+     * @param encodeStartTime - if &gt;0, this is a latency timestamp to be included in the update message.
      * @param error - detailed error information in case of encoding failures.
-     * @return <0 if encoding fails, 0 otherwise.
+     * @return &lt;0 if encoding fails, 0 otherwise.
      */
 	public int encodeUpdate(Channel channel, 
 	        ItemInfo itemInfo, TransportBuffer msgBuf, PostUserInfo postUserInfo,
@@ -496,9 +496,9 @@ public class ItemEncoder
      * @param itemInfo - market data item to encode refresh message for.
      * @param msgBuf  - TransportBuffer to encode refresh message into.
      * @param postUserInfo 
-     * @param encodeStartTime - if >0, this is a latency timestamp to be included in the refresh message.
+     * @param encodeStartTime - if &gt;0, this is a latency timestamp to be included in the refresh message.
      * @param error - detailed error information in case of encoding failures.
-     * @return <0 if encoding fails, 0 otherwise.
+     * @return &lt;0 if encoding fails, 0 otherwise.
      */
     public int encodeRefresh(Channel channel,
             ItemInfo itemInfo, TransportBuffer msgBuf, PostUserInfo postUserInfo, long encodeStartTime, Error error)

--- a/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/LatencyRandomArray.java
+++ b/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/LatencyRandomArray.java
@@ -21,7 +21,7 @@ public class LatencyRandomArray
 	 * 
 	 * @param opts options for generating latency array.
 	 *  
-	 * @return < 0 if latency array options are invalid, 0 otherwise. 
+	 * @return &lt; 0 if latency array options are invalid, 0 otherwise. 
 	 */
 	public int create(LatencyRandomArrayOptions opts)
 	{

--- a/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/ProviderSession.java
+++ b/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/ProviderSession.java
@@ -151,7 +151,7 @@ public class ProviderSession
      * @param error - Error information populated when there is a failure to
      *            obtain buffers for measuring size.
      * 
-     * @return <0 if failure, 0 otherwise.
+     * @return &lt;0 if failure, 0 otherwise.
      */
     public int printEstimatedMsgSizes(Error error)
     {

--- a/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/ProviderThread.java
+++ b/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/ProviderThread.java
@@ -269,7 +269,7 @@ public class ProviderThread extends Thread
      * @param length - buffer size to get
      * @param error - error populated when get transport buffer fails
      * 
-     * @return <0 if get buffer fails, 0 otherwise.
+     * @return &lt;0 if get buffer fails, 0 otherwise.
      */
     public int getItemMsgBuffer(ProviderSession session, int length, Error error)
     {
@@ -384,7 +384,7 @@ public class ProviderThread extends Thread
      * @param session - client channel session 
      * @param allowPack - if false, write buffer without packing. if true, pack according to configuration.
      * @param error - error information populated in case of failure.
-     * @return <0 in case of error, 0 otherwise
+     * @return &lt;0 in case of error, 0 otherwise
      */
     public int sendItemMsgBuffer(ProviderSession session, boolean allowPack, Error error)
     {

--- a/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/ResourceUsageStats.java
+++ b/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/common/ResourceUsageStats.java
@@ -3,7 +3,7 @@ package com.thomsonreuters.upa.perftools.common;
 import java.lang.management.ManagementFactory;
 import com.sun.management.OperatingSystemMXBean;
 
-/** Resource Statistics (CPU & Memory Usage) */
+/** Resource Statistics (CPU &amp; Memory Usage) */
 public class ResourceUsageStats
 {
     // note: Java 7 (Oracle JDK) introduced the following method for obtaining the current proceses's CPU usage.

--- a/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/upajprovperf/LoginProvider.java
+++ b/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/upajprovperf/LoginProvider.java
@@ -68,7 +68,7 @@ public class LoginProvider
      * @param dIter - The decode iterator
      * @param error - Error information in case of failure
      * @return {@link PerfToolsReturnCodes#SUCCESS} for successful request
-     *         processing, < {@link PerfToolsReturnCodes#SUCCESS} when request
+     *         processing, &lt; {@link PerfToolsReturnCodes#SUCCESS} when request
      *         processing fails.
      */
     public int processMsg(ChannelHandler channelHandler, ClientChannelInfo clientChannelInfo, Msg msg, DecodeIterator dIter, Error error)

--- a/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/upajtransportperf/TransportChannelHandler.java
+++ b/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/upajtransportperf/TransportChannelHandler.java
@@ -247,7 +247,7 @@ public class TransportChannelHandler
      * @param stopTimeNsec - stop time in nano seconds
      * @param error Gives detailed information about error if any occurred
      *            during socket operations.
-     * @return negative value in case of error, >=0 if no errors.
+     * @return negative value in case of error, &gt;=0 if no errors.
      */
     public int readChannels(long stopTimeNsec, Error error)
     {
@@ -380,7 +380,7 @@ public class TransportChannelHandler
      * @param clientChannelInfo - client channel information
      * @param error Gives detailed information about error if any occurred
      *            during socket operations.
-     * @return negative value in case of error, >=0 if no errors.
+     * @return negative value in case of error, &gt;=0 if no errors.
      */
     public int initializeChannel(ClientChannelInfo clientChannelInfo, Error error)
     {
@@ -416,7 +416,7 @@ public class TransportChannelHandler
      * @param waitTimeMilliSec - wait time in milli seconds to try initialize
      *            channel
      * @param error - error information populated when error occurs
-     * @return < 0 if there is any error,
+     * @return &lt; 0 if there is any error,
      *         TransportReturnCodes.CHAN_INIT_IN_PROGRESS (2) if channel
      *         initialization in progress
      */

--- a/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/upajtransportperf/TransportSession.java
+++ b/Java/Eta/Applications/PerfTools/com/thomsonreuters/upa/perftools/upajtransportperf/TransportSession.java
@@ -49,7 +49,7 @@ public class TransportSession
      * Send a burst of messages for one tick.
      * @param handler - Transport thread sending messages.
      * @param error - Gives detailed information about error if any occurred during socket operations.
-     * @return negative value in case of error, >=0 if no errors.
+     * @return negative value in case of error, &gt;=0 if no errors.
      */
     public int sendMsgBurst(TransportThread handler, Error error)
     {

--- a/Java/Eta/Applications/Shared/com/thomsonreuters/upa/shared/ProviderSession.java
+++ b/Java/Eta/Applications/Shared/com/thomsonreuters/upa/shared/ProviderSession.java
@@ -47,7 +47,7 @@ import com.thomsonreuters.upa.transport.WritePriorities;
  * <li>For new request from the client, call
  * {@link #read(Channel, Error, ReceivedMsgCallback)} that initializes client socket
  * channel to complete channel handshake and then read and processes the request
- * sage from the client channel.</li> </ul>
+ * sage from the client channel.</li> </ol>
  */
 public class ProviderSession
 {

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/AckMsg.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/AckMsg.java
@@ -16,9 +16,9 @@ import com.thomsonreuters.upa.codec.Buffer;
 public interface AckMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -27,9 +27,9 @@ public interface AckMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Text flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Text flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -38,9 +38,9 @@ public interface AckMsg extends Msg
     public boolean checkHasText();
 
     /**
-     * Checks the presence of the Private Stream flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Private Stream flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -49,9 +49,9 @@ public interface AckMsg extends Msg
     public boolean checkPrivateStream();
 
     /**
-     * Checks the presence of the Sequence Number flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Sequence Number flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -60,9 +60,9 @@ public interface AckMsg extends Msg
     public boolean checkHasSeqNum();
 
     /**
-     * Checks the presence of the Message Key flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -71,9 +71,9 @@ public interface AckMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the NAK Code flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the NAK Code flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -82,9 +82,9 @@ public interface AckMsg extends Msg
     public boolean checkHasNakCode();
 
     /**
-     * Checks the presence of the Qualified Stream flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Qualified Stream flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -93,63 +93,63 @@ public interface AckMsg extends Msg
     public boolean checkQualifiedStream();
 
     /**
-     * Applies the Extended Header indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Text indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Text indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasText();
 
     /**
-     ** Applies the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     ** Applies the Private Stream indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/
     public void applyPrivateStream();
 
     /**
-     * Applies the Sequence Number indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Sequence Number indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasSeqNum();
 
     /**
-     * Applies the Message Key indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the NAK Code indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the NAK Code indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasNakCode();
 
     /**
-     * Applies the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Qualified Stream indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/Array.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/Array.java
@@ -89,15 +89,16 @@ import com.thomsonreuters.upa.codec.Buffer;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * int retval;
  * 
- *  //decode array
- * if (array.decode(decIter) >= {@link CodecReturnCodes#SUCCESS})
+ * //decode array
+ * if (array.decode(decIter) >= CodecReturnCodes.SUCCESS)
  * {
  *    //decode array entry
- *    while((retval = arrayentry.decode(decIter, entrybuffer)) != {@link CodecReturnCodes#END_OF_CONTAINER})
+ *    while((retval = arrayentry.decode(decIter, entrybuffer)) != CodecReturnCodes.END_OF_CONTAINER)
  *    {
- *          if(retval < {@link CodecReturnCodes#SUCCESS})
+ *          if(retval < CodecReturnCodes.SUCCESS)
  *          {
  *              //decoding failure tends to be unrecoverable
  *          }
@@ -111,6 +112,7 @@ import com.thomsonreuters.upa.codec.Buffer;
  *    }
  * }
  * 
+ * }
  * </pre>
  * 
  * </li>

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/CloseMsg.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/CloseMsg.java
@@ -11,9 +11,9 @@ package com.thomsonreuters.upa.codec;
 public interface CloseMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -22,9 +22,9 @@ public interface CloseMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Acknowledgment indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Acknowledgment indication flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -33,18 +33,18 @@ public interface CloseMsg extends Msg
     public boolean checkAck();
 
     /**
-     * Sets the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Sets the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Sets the Acknowledgment indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Sets the Acknowledgment indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/DataDictionary.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/DataDictionary.java
@@ -95,7 +95,7 @@ public interface DataDictionary
      *            iterator must be cleared and initialized to the buffer to be used for encoding.
      * 
      * @param currentFid Tracks which fields have been encoded in case of
-     *            multi-part encoding. Must be initialized to dictionary->minFid
+     *            multi-part encoding. Must be initialized to {@literal dictionary->minFid}
      *            on the first call and is updated with each successfully encoded part.
      * 
      * @param verbosity The desired verbosity to encode.

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/DecodeIterator.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/DecodeIterator.java
@@ -41,8 +41,9 @@ import com.thomsonreuters.upa.transport.TransportBuffer;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * //Create DecodeIterator using CodecFactory
- * DecodeIterator decIter = CodecFactory.createDecodeIterator()}; 
+ * DecodeIterator decIter = CodecFactory.createDecodeIterator(); 
  * 
  * //Clear iterator 
  * clear();
@@ -58,6 +59,7 @@ import com.thomsonreuters.upa.transport.TransportBuffer;
  * 
  * //do decoding using iterator
  *  
+ * }
  * </pre>
  * 
  * </li>

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/ElementList.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/ElementList.java
@@ -25,7 +25,6 @@ import com.thomsonreuters.upa.codec.Buffer;
  * The third encodes as a blank {@link Real} value.</li>
  * <li>
  * The fourth encodes as an {@link ElementList} container type.</li>
- * </li>
  * </ul>
  * <p>
  * The pattern used to encode the fourth entry can be used to encode any
@@ -138,6 +137,7 @@ import com.thomsonreuters.upa.codec.Buffer;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * //decode into the element list structure
  * if(retVal  = elementList.decode(decIter, localSetDefs)) >= CodecReturnCodes.SUCCESS)
  * {
@@ -169,6 +169,7 @@ import com.thomsonreuters.upa.codec.Buffer;
  *      //decoding failure tends to be unrecoverable
  * }
  * 
+ * }
  * </pre>
  * 
  * </li>
@@ -235,9 +236,9 @@ public interface ElementList extends XMLDecoder
     public int decode(DecodeIterator iter, LocalElementSetDefDb localSetDb);
 
     /**
-     * Checks the presence of the Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Information presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -246,9 +247,9 @@ public interface ElementList extends XMLDecoder
     public boolean checkHasInfo();
 
     /**
-     * Checks the presence of the Standard Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Standard Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -257,9 +258,9 @@ public interface ElementList extends XMLDecoder
     public boolean checkHasStandardData();
 
     /**
-     * Checks the presence of the Set Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Set Id presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -268,9 +269,9 @@ public interface ElementList extends XMLDecoder
     public boolean checkHasSetId();
 
     /**
-     * Checks the presence of the Set Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Set Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -279,36 +280,36 @@ public interface ElementList extends XMLDecoder
     public boolean checkHasSetData();
 
     /**
-     * Applies the Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Information presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasInfo();
 
     /**
-     * Applies the Standard Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Standard Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasStandardData();
 
     /**
-     * Applies the Set Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Set Id presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSetId();
 
     /**
-     * Applies the Set Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Set Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/EncodeIterator.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/EncodeIterator.java
@@ -45,8 +45,9 @@ import com.thomsonreuters.upa.transport.TransportBuffer;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * //Create EncodeIterator using CodecFactory
- * EncodeIterator encIter = CodecFactory.createEncodeIterator()}; 
+ * EncodeIterator encIter = CodecFactory.createEncodeIterator(); 
  * 
  * //Clear iterator 
  * clear();
@@ -61,6 +62,7 @@ import com.thomsonreuters.upa.transport.TransportBuffer;
  * }
  * 
  * //Do encoding using iterator
+ * }
  * </pre>
  * 
  * </li>

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/FieldList.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/FieldList.java
@@ -38,7 +38,6 @@ import com.thomsonreuters.upa.codec.Buffer;
  * 
  * <pre>
  * 
- * 
  * FieldList fieldList = CodecFactory.createFieldList();
  * 
  * // create a single FieldEntry and reuse for each entry
@@ -257,9 +256,9 @@ public interface FieldList extends XMLDecoder
     public int decode(DecodeIterator iter, LocalFieldSetDefDb localSetDb);
 
     /**
-     * Checks the presence of the Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Information presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -268,9 +267,9 @@ public interface FieldList extends XMLDecoder
     public boolean checkHasInfo();
 
     /**
-     * Checks the presence of the Standard Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Standard Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -279,9 +278,9 @@ public interface FieldList extends XMLDecoder
     public boolean checkHasStandardData();
 
     /**
-     * Checks the presence of the Set Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Set Id presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -290,9 +289,9 @@ public interface FieldList extends XMLDecoder
     public boolean checkHasSetId();
 
     /**
-     * Checks the presence of the Set Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Set Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -301,36 +300,36 @@ public interface FieldList extends XMLDecoder
     public boolean checkHasSetData();
 
     /**
-     * Applies the Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Information presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasInfo();
 
     /**
-     * Applies the Standard Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Standard Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasStandardData();
 
     /**
-     * Applies the Set Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Set Id presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSetId();
 
     /**
-     * Applies the Set Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Set Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/FilterEntry.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/FilterEntry.java
@@ -94,9 +94,9 @@ public interface FilterEntry
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -105,9 +105,9 @@ public interface FilterEntry
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Container Type presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Container Type presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -116,18 +116,18 @@ public interface FilterEntry
     public boolean checkHasContainerType();
 
     /**
-     * Applies the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Container Type presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Container Type presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/FilterList.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/FilterList.java
@@ -256,9 +256,9 @@ public interface FilterList extends XMLDecoder
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the Per Entry Permission presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Per Entry Permission presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -267,9 +267,9 @@ public interface FilterList extends XMLDecoder
     public boolean checkHasPerEntryPermData();
 
     /**
-     * Checks the presence of the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Total Count Hint presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -278,18 +278,18 @@ public interface FilterList extends XMLDecoder
     public boolean checkHasTotalCountHint();
 
     /**
-     * Applies the Per Entry Permission presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Per Entry Permission presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasPerEntryPermData();
 
     /**
-     * Applies the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Total Count Hint presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/GenericMsg.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/GenericMsg.java
@@ -22,9 +22,9 @@ import com.thomsonreuters.upa.codec.Buffer;
 public interface GenericMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -33,9 +33,9 @@ public interface GenericMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Permission Expression presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -44,9 +44,9 @@ public interface GenericMsg extends Msg
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -55,9 +55,9 @@ public interface GenericMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -66,9 +66,9 @@ public interface GenericMsg extends Msg
     public boolean checkHasSeqNum();
 
     /**
-     * Checks the presence of the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Part Number presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -77,9 +77,9 @@ public interface GenericMsg extends Msg
     public boolean checkHasPartNum();
 
     /**
-     * Checks the presence of the Message Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Complete indication flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -88,9 +88,9 @@ public interface GenericMsg extends Msg
     public boolean checkMessageComplete();
 
     /**
-     * Checks the presence of the Secondary Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Secondary Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -99,63 +99,62 @@ public interface GenericMsg extends Msg
     public boolean checkHasSecondarySeqNum();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Permission Expression presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasSeqNum();
 
     /**
-     * Applies the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Part Number presence flag.
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPartNum();
 
     /**
-     * Applies the Message Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Complete indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyMessageComplete();
 
     /**
-     * Applies the Secondary Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Secondary Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/Map.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/Map.java
@@ -295,9 +295,9 @@ public interface Map extends XMLDecoder
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the local Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the local Set Definition presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -306,9 +306,9 @@ public interface Map extends XMLDecoder
     public boolean checkHasSetDefs();
 
     /**
-     * Checks the presence of the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Summary Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -317,9 +317,9 @@ public interface Map extends XMLDecoder
     public boolean checkHasSummaryData();
 
     /**
-     * Checks the presence of the Per Entry Permission presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Per Entry Permission presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -328,9 +328,9 @@ public interface Map extends XMLDecoder
     public boolean checkHasPerEntryPermData();
 
     /**
-     * Checks the presence of the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Total Count Hint presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -339,9 +339,9 @@ public interface Map extends XMLDecoder
     public boolean checkHasTotalCountHint();
 
     /**
-     * Checks the presence of the Key Field Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Key Field Id presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -350,45 +350,45 @@ public interface Map extends XMLDecoder
     public boolean checkHasKeyFieldId();
 
     /**
-     * Applies the local Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the local Set Definition presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSetDefs();
 
     /**
-     * Applies the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Summary Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSummaryData();
 
     /**
-     * Applies the Per Entry Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Per Entry Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasPerEntryPermData();
 
     /**
-     * Applies the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Total Count Hint presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasTotalCountHint();
 
     /**
-     * Applies the Key Field Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Key Field Id presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/MapEntry.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/MapEntry.java
@@ -565,9 +565,9 @@ public interface MapEntry
     public int decode(DecodeIterator iter, Object keyData);
 
     /**
-     * Checks the presence of the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -576,9 +576,9 @@ public interface MapEntry
     public boolean checkHasPermData();
 
     /**
-     * Applies the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/MsgKey.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/MsgKey.java
@@ -14,9 +14,9 @@ import com.thomsonreuters.upa.codec.Buffer;
 public interface MsgKey
 {
     /**
-     * Checks the presence of the Service Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Service Id presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -26,9 +26,8 @@ public interface MsgKey
     public boolean checkHasServiceId();
 
     /**
-     * Checks the presence of the Name presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Name presence flag.
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -37,9 +36,9 @@ public interface MsgKey
     public boolean checkHasName();
 
     /**
-     * Checks the presence of the Name Type presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Name Type presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -48,9 +47,9 @@ public interface MsgKey
     public boolean checkHasNameType();
 
     /**
-     * Checks the presence of the Filter presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Filter presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -59,9 +58,9 @@ public interface MsgKey
     public boolean checkHasFilter();
 
     /**
-     * Checks the presence of the Identifier presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Identifier presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -70,9 +69,9 @@ public interface MsgKey
     public boolean checkHasIdentifier();
 
     /**
-     * Checks the presence of the Attribute presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Attribute presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -81,54 +80,54 @@ public interface MsgKey
     public boolean checkHasAttrib();
 
     /**
-     * Applies the Service Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Service Id presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasServiceId();
 
     /**
-     * Applies the Name presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Name presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasName();
 
     /**
-     * Applies the Name Type presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Name Type presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasNameType();
 
     /**
-     * Applies the Filter presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Filter presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasFilter();
 
     /**
-     * Applies the Identifier presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Identifier presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasIdentifier();
 
     /**
-     * Applies the Attribute presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Attribute presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/PostMsg.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/PostMsg.java
@@ -20,9 +20,9 @@ import com.thomsonreuters.upa.codec.Buffer;
 public interface PostMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -31,9 +31,9 @@ public interface PostMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Post Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post Id presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -42,9 +42,9 @@ public interface PostMsg extends Msg
     public boolean checkHasPostId();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -53,9 +53,9 @@ public interface PostMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -64,9 +64,9 @@ public interface PostMsg extends Msg
     public boolean checkHasSeqNum();
 
     /**
-     * Checks the presence of the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Part Number presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -75,9 +75,9 @@ public interface PostMsg extends Msg
     public boolean checkHasPartNum();
 
     /**
-     * Checks the presence of the Post Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post Complete indication flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -86,9 +86,9 @@ public interface PostMsg extends Msg
     public boolean checkPostComplete();
 
     /**
-     * Checks the presence of the Acknowledgment indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Acknowledgment indication flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -97,9 +97,9 @@ public interface PostMsg extends Msg
     public boolean checkAck();
 
     /**
-     * Checks the presence of the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Permission Expression presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -108,9 +108,9 @@ public interface PostMsg extends Msg
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Post User Rights presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post User Rights presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -119,81 +119,81 @@ public interface PostMsg extends Msg
     public boolean checkHasPostUserRights();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Post Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post Id presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPostId();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasSeqNum();
 
     /**
-     * Applies the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Part Number presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPartNum();
 
     /**
-     * Applies the Post Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post Complete indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyPostComplete();
 
     /**
-     * Applies the Acknowledgment indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Acknowledgment indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyAck();
 
     /**
-     * Applies the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Permission Expression presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Post User Rights presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post User Rights presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/RealHints.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/RealHints.java
@@ -11,6 +11,7 @@ package com.thomsonreuters.upa.codec;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * if ({@link Real#hint()} < {@link #FRACTION_1})
  * {
  *      outputValue = Real.value()*(pow(10,(Real.hint() - {@link #EXPONENT0})));
@@ -18,6 +19,7 @@ package com.thomsonreuters.upa.codec;
  * else
  * {
  *      outputValue = Real.value()*(pow(2,(Real.hint() - {@link #FRACTION_1})));
+ * }
  * }
  * </pre>
  * </li>
@@ -29,6 +31,7 @@ package com.thomsonreuters.upa.codec;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * if (inputHint < {@link #FRACTION_1})
  * {
  *      Real.value = (inputValue)/(pow(10,(inputHint - {@link #EXPONENT0})));
@@ -36,6 +39,7 @@ package com.thomsonreuters.upa.codec;
  * else
  * {
  *      Real.value = (inputValue)/(pow(2,(inputHint - {@link #FRACTION_1})));
+ * }
  * }
  * </pre>
  * </li>

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/RefreshMsg.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/RefreshMsg.java
@@ -45,9 +45,9 @@ import com.thomsonreuters.upa.codec.State;
 public interface RefreshMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -56,9 +56,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -67,10 +67,10 @@ public interface RefreshMsg extends Msg
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
      * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
+     *
      * @see Msg#flags()
      * 
      * @return true - if exists; false if does not exist.
@@ -78,9 +78,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Sequence Number presence flag.
+     *
+     * <p>* Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -89,9 +89,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasSeqNum();
 
     /**
-     * Checks the presence of the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Part Number presence flag.
+     *
+     * <p>* Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -100,9 +100,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasPartNum();
 
     /**
-     * Checks the presence of the Solicited indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Solicited indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -111,9 +111,9 @@ public interface RefreshMsg extends Msg
     public boolean checkSolicited();
 
     /**
-     * Checks the presence of the Refresh Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Refresh Complete indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -122,9 +122,9 @@ public interface RefreshMsg extends Msg
     public boolean checkRefreshComplete();
 
     /**
-     * Checks the presence of the Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -133,9 +133,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasQos();
 
     /**
-     * Checks the presence of the Clear Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Clear Cache indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -144,9 +144,9 @@ public interface RefreshMsg extends Msg
     public boolean checkClearCache();
 
     /**
-     * Checks the presence of the Do Not Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Do Not Cache indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -155,9 +155,9 @@ public interface RefreshMsg extends Msg
     public boolean checkDoNotCache();
 
     /**
-     * Checks the presence of the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -166,9 +166,9 @@ public interface RefreshMsg extends Msg
     public boolean checkPrivateStream();
 
     /**
-     * Checks the presence of the Post User Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post User Information presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -177,9 +177,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasPostUserInfo();
 
     /**
-     * Checks the presence of the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -188,117 +188,117 @@ public interface RefreshMsg extends Msg
     public boolean checkQualifiedStream();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Sequence Number presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasSeqNum();
 
     /**
-     * Applies the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Part Number presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPartNum();
 
     /**
-     * Applies the Solicited indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Solicited indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applySolicited();
 
     /**
-     * Applies the Refresh Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Refresh Complete indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyRefreshComplete();
 
     /**
-     * Applies the Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasQos();
 
     /**
-     * Applies the Clear Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Clear Cache indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyClearCache();
 
     /**
-     * Applies the Do Not Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Do Not Cache indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyDoNotCache();
 
     /**
-     * Applies the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/
     public void applyPrivateStream();
 
     /**
-     * Applies the Post User Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post User Information presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPostUserInfo();
 
     /**
-     * Applies the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/RequestMsg.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/RequestMsg.java
@@ -31,9 +31,9 @@ import com.thomsonreuters.upa.codec.Qos;
 public interface RequestMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -42,9 +42,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Priority presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Priority presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -53,9 +53,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasPriority();
 
     /**
-     * Checks the presence of the Streaming indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Streaming indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -64,9 +64,9 @@ public interface RequestMsg extends Msg
     public boolean checkStreaming();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -75,9 +75,9 @@ public interface RequestMsg extends Msg
     public boolean checkMsgKeyInUpdates();
 
     /**
-     * Checks the presence of the Conflation Info presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Conflation Info presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -86,9 +86,9 @@ public interface RequestMsg extends Msg
     public boolean checkConfInfoInUpdates();
 
     /**
-     * Checks the presence of the No Refresh indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the No Refresh indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -97,9 +97,9 @@ public interface RequestMsg extends Msg
     public boolean checkNoRefresh();
 
     /**
-     * Checks the presence of the Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -108,9 +108,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasQos();
 
     /**
-     * Checks the presence of the Worst Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Worst Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -119,9 +119,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasWorstQos();
 
     /**
-     ** Checks the presence of the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     ** Checks the presence of the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      ** 
@@ -130,9 +130,9 @@ public interface RequestMsg extends Msg
     public boolean checkPrivateStream();
 
     /**
-     * Checks the presence of the Pause indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Pause indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -141,9 +141,9 @@ public interface RequestMsg extends Msg
     public boolean checkPause();
 
     /**
-     * Checks the presence of the View indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the View indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -152,9 +152,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasView();
 
     /**
-     * Checks the presence of the Batch indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Batch indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -163,9 +163,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasBatch();
 
     /**
-     ** Checks the presence of the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     ** Checks the presence of the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      ** 
@@ -174,117 +174,117 @@ public interface RequestMsg extends Msg
     public boolean checkQualifiedStream();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Priority presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Priority presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPriority();
 
     /**
-     * Applies the Streaming indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Streaming indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyStreaming();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyMsgKeyInUpdates();
 
     /**
-     * Applies the Conflation Information in Updates indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Conflation Information in Updates indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyConfInfoInUpdates();
 
     /**
-     * Applies the No Refresh indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the No Refresh indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyNoRefresh();
 
     /**
-     * Applies the Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasQos();
 
     /**
-     * Applies the Worst Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Worst Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasWorstQos();
 
     /**
-     ** Applies the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     ** Applies the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/
     public void applyPrivateStream();
 
     /**
-     * Applies the Pause indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Pause indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyPause();
 
     /**
-     * Applies the View indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the View indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasView();
 
     /**
-     * Applies the Batch indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Batch indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasBatch();
 
     /**
-     ** Applies the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     ** Applies the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/Series.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/Series.java
@@ -254,9 +254,9 @@ public interface Series extends XMLDecoder
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Set Definition presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -265,9 +265,9 @@ public interface Series extends XMLDecoder
     public boolean checkHasSetDefs();
 
     /**
-     * Checks the presence of the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Summary Data presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -276,9 +276,9 @@ public interface Series extends XMLDecoder
     public boolean checkHasSummaryData();
 
     /**
-     * Checks the presence of the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Total Count Hint presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -287,27 +287,27 @@ public interface Series extends XMLDecoder
     public boolean checkHasTotalCountHint();
 
     /**
-     * Applies the local Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the local Set Definition presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSetDefs();
 
     /**
-     * Applies the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Summary Data presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSummaryData();
 
     /**
-     * Applies the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Total Count Hint presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/StatusMsg.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/StatusMsg.java
@@ -20,9 +20,9 @@ import com.thomsonreuters.upa.codec.State;
 public interface StatusMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -31,9 +31,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -42,9 +42,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -53,9 +53,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the Group Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Group Id presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -64,9 +64,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasGroupId();
 
     /**
-     * Checks the presence of the State presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the State presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -75,9 +75,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasState();
 
     /**
-     * Checks the presence of the Clear Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Clear Cache indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -86,9 +86,9 @@ public interface StatusMsg extends Msg
     public boolean checkClearCache();
 
     /**
-     * Checks the presence of the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -97,9 +97,9 @@ public interface StatusMsg extends Msg
     public boolean checkPrivateStream();
 
     /**
-     * Checks the presence of the Post User Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post User Information presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -108,9 +108,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasPostUserInfo();
 
     /**
-     * Checks the presence of the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -119,81 +119,81 @@ public interface StatusMsg extends Msg
     public boolean checkQualifiedStream();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the Group Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Group Id presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasGroupId();
 
     /**
-     * Applies the State presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the State presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasState();
 
     /**
-     * Applies the Clear Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Clear Cache indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyClearCache();
 
     /**
-     ** Applies the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     ** Applies the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/
     public void applyPrivateStream();
 
     /**
-     * Applies the Post User Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post User Information presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPostUserInfo();
 
     /**
-     * Applies the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/UpdateMsg.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/UpdateMsg.java
@@ -23,9 +23,9 @@ import com.thomsonreuters.upa.rdm.UpdateEventTypes;
 public interface UpdateMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -34,9 +34,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -45,9 +45,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -56,9 +56,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Sequence Number presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -67,9 +67,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasSeqNum();
 
     /**
-     * Checks the presence of the Conflation Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Conflation Information presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -78,9 +78,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasConfInfo();
 
     /**
-     * Checks the presence of the Do Not Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Do Not Cache indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -89,9 +89,9 @@ public interface UpdateMsg extends Msg
     public boolean checkDoNotCache();
 
     /**
-     * Checks the presence of the Do Not Conflate indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Do Not Conflate indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -100,9 +100,9 @@ public interface UpdateMsg extends Msg
     public boolean checkDoNotConflate();
 
     /**
-     * Checks the presence of the Do Not Ripple indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Do Not Ripple indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -111,9 +111,9 @@ public interface UpdateMsg extends Msg
     public boolean checkDoNotRipple();
 
     /**
-     * Checks the presence of the Post User Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post User Information presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -122,9 +122,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasPostUserInfo();
 
     /**
-     * Checks the presence of the Discardable presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Discardable presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -133,90 +133,90 @@ public interface UpdateMsg extends Msg
     public boolean checkDiscardable();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Sequence Number presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasSeqNum();
 
     /**
-     * Applies the Conflation Info presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Conflation Info presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasConfInfo();
 
     /**
-     * Applies the Do Not Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Do Not Cache indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyDoNotCache();
 
     /**
-     * Applies the Do Not Conflate indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Do Not Conflate indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyDoNotConflate();
 
     /**
-     * Applies the Do Not Ripple indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Do Not Ripple indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyDoNotRipple();
 
     /**
-     * Applies the Post User Info presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post User Info presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPostUserInfo();
 
     /**
-     * Applies the Discardable presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Discardable presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/Vector.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/Vector.java
@@ -144,6 +144,7 @@ import com.thomsonreuters.upa.codec.Buffer;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * //decode contents into the vector
  * if((retVal = vector.decode(decIter) >= CodecReturnCodes.SUCCESS)
  * {
@@ -180,6 +181,7 @@ import com.thomsonreuters.upa.codec.Buffer;
  * else
  * {
  *      //decoding failure tends to be unrecoverable
+ * }
  * }
  * </pre>
  * 
@@ -277,9 +279,9 @@ public interface Vector extends XMLDecoder
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the local Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the local Set Definition presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -288,9 +290,9 @@ public interface Vector extends XMLDecoder
     public boolean checkHasSetDefs();
 
     /**
-     * Checks the presence of the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Summary Data presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -299,9 +301,9 @@ public interface Vector extends XMLDecoder
     public boolean checkHasSummaryData();
 
     /**
-     * Checks the presence of the Per Entry Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Per Entry Permission Data presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -310,9 +312,9 @@ public interface Vector extends XMLDecoder
     public boolean checkHasPerEntryPermData();
 
     /**
-     * Checks the presence of the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Total Count Hint presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -321,9 +323,9 @@ public interface Vector extends XMLDecoder
     public boolean checkHasTotalCountHint();
 
     /**
-     * Checks the presence of the Supports Sorting indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Supports Sorting indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -332,45 +334,45 @@ public interface Vector extends XMLDecoder
     public boolean checkSupportsSorting();
 
     /**
-     * Applies the local Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the local Set Definition presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSetDefs();
 
     /**
-     * Applies the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Summary Data presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSummaryData();
 
     /**
-     * Applies the Per Entry Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Per Entry Permission Data presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasPerEntryPermData();
 
     /**
-     * Applies the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Total Count Hint presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasTotalCountHint();
 
     /**
-     * Applies the Supports Sorting indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Supports Sorting indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/VectorEntry.java
+++ b/Java/Eta/Source/Stubs/external/com/thomsonreuters/upa/codec/VectorEntry.java
@@ -89,9 +89,9 @@ public interface VectorEntry
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -100,9 +100,9 @@ public interface VectorEntry
     public boolean checkHasPermData();
 
     /**
-     * Applies the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/ansipage/Page.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/ansipage/Page.java
@@ -54,14 +54,16 @@ public class Page implements Cloneable
   /**
    * <P>The decode() method analyzes and parses the ANSI encoded update stream
    * and updates the PageUpdate list as well as the corresponding PageCell objects
-   * of the Page image.  </P>
-   * Decoding an ANSI stream is accomplished by using a finite
+   * of the Page image.  
+   * 
+   * <p>Decoding an ANSI stream is accomplished by using a finite
    * state machine.  Each of the ANSI escape sequences is parsed according to the state
    * into which the previous characters have the machine.  As the sequences are recognized,
    * the page image is modified. This allows the update list to be
    * sized without knowledge of the maximum amount of update information that a source
    * can communicate.  The page image should not be altered between calls to the decode()
-   * method.</P>
+   * method.
+   * 
    * <ul><li>As decode() is called, entries are added to the update list for the following
    *  reasons:
    * <li>For each repositioning of the cursor an entry with zero length is generated for that point.

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/AckMsg.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/AckMsg.java
@@ -16,9 +16,9 @@ import com.thomsonreuters.upa.codec.Buffer;
 public interface AckMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -27,9 +27,9 @@ public interface AckMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Text flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Text flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -38,9 +38,9 @@ public interface AckMsg extends Msg
     public boolean checkHasText();
 
     /**
-     * Checks the presence of the Private Stream flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Private Stream flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -49,9 +49,9 @@ public interface AckMsg extends Msg
     public boolean checkPrivateStream();
 
     /**
-     * Checks the presence of the Sequence Number flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Sequence Number flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -60,9 +60,9 @@ public interface AckMsg extends Msg
     public boolean checkHasSeqNum();
 
     /**
-     * Checks the presence of the Message Key flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -71,9 +71,9 @@ public interface AckMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the NAK Code flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the NAK Code flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -82,9 +82,9 @@ public interface AckMsg extends Msg
     public boolean checkHasNakCode();
 
     /**
-     * Checks the presence of the Qualified Stream flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Qualified Stream flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -93,63 +93,63 @@ public interface AckMsg extends Msg
     public boolean checkQualifiedStream();
 
     /**
-     * Applies the Extended Header indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Text indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Text indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasText();
 
     /**
-     ** Applies the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     ** Applies the Private Stream indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/
     public void applyPrivateStream();
 
     /**
-     * Applies the Sequence Number indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Sequence Number indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasSeqNum();
 
     /**
-     * Applies the Message Key indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the NAK Code indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the NAK Code indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasNakCode();
 
     /**
-     * Applies the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Qualified Stream indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/Array.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/Array.java
@@ -89,15 +89,16 @@ import com.thomsonreuters.upa.codec.Buffer;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * int retval;
  * 
- *  //decode array
- * if (array.decode(decIter) >= {@link CodecReturnCodes#SUCCESS})
+ * //decode array
+ * if (array.decode(decIter) >= CodecReturnCodes.SUCCESS)
  * {
  *    //decode array entry
- *    while((retval = arrayentry.decode(decIter, entrybuffer)) != {@link CodecReturnCodes#END_OF_CONTAINER})
+ *    while((retval = arrayentry.decode(decIter, entrybuffer)) != CodecReturnCodes.END_OF_CONTAINER)
  *    {
- *          if(retval < {@link CodecReturnCodes#SUCCESS})
+ *          if(retval < CodecReturnCodes.SUCCESS)
  *          {
  *              //decoding failure tends to be unrecoverable
  *          }
@@ -111,6 +112,7 @@ import com.thomsonreuters.upa.codec.Buffer;
  *    }
  * }
  * 
+ * }
  * </pre>
  * 
  * </li>

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/CloseMsg.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/CloseMsg.java
@@ -11,9 +11,9 @@ package com.thomsonreuters.upa.codec;
 public interface CloseMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -22,9 +22,9 @@ public interface CloseMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Acknowledgment indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Acknowledgment indication flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -33,18 +33,18 @@ public interface CloseMsg extends Msg
     public boolean checkAck();
 
     /**
-     * Sets the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Sets the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Sets the Acknowledgment indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Sets the Acknowledgment indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/DataDictionary.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/DataDictionary.java
@@ -95,7 +95,7 @@ public interface DataDictionary
      *            iterator must be cleared and initialized to the buffer to be used for encoding.
      * 
      * @param currentFid Tracks which fields have been encoded in case of
-     *            multi-part encoding. Must be initialized to dictionary->minFid
+     *            multi-part encoding. Must be initialized to {@literal dictionary->minFid}
      *            on the first call and is updated with each successfully encoded part.
      * 
      * @param verbosity The desired verbosity to encode.

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/DecodeIterator.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/DecodeIterator.java
@@ -41,8 +41,9 @@ import com.thomsonreuters.upa.transport.TransportBuffer;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * //Create DecodeIterator using CodecFactory
- * DecodeIterator decIter = CodecFactory.createDecodeIterator()}; 
+ * DecodeIterator decIter = CodecFactory.createDecodeIterator(); 
  * 
  * //Clear iterator 
  * clear();
@@ -58,6 +59,7 @@ import com.thomsonreuters.upa.transport.TransportBuffer;
  * 
  * //do decoding using iterator
  *  
+ * }
  * </pre>
  * 
  * </li>

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/ElementList.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/ElementList.java
@@ -25,7 +25,6 @@ import com.thomsonreuters.upa.codec.Buffer;
  * The third encodes as a blank {@link Real} value.</li>
  * <li>
  * The fourth encodes as an {@link ElementList} container type.</li>
- * </li>
  * </ul>
  * <p>
  * The pattern used to encode the fourth entry can be used to encode any
@@ -138,6 +137,7 @@ import com.thomsonreuters.upa.codec.Buffer;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * //decode into the element list structure
  * if(retVal  = elementList.decode(decIter, localSetDefs)) >= CodecReturnCodes.SUCCESS)
  * {
@@ -169,6 +169,7 @@ import com.thomsonreuters.upa.codec.Buffer;
  *      //decoding failure tends to be unrecoverable
  * }
  * 
+ * }
  * </pre>
  * 
  * </li>
@@ -235,9 +236,9 @@ public interface ElementList extends XMLDecoder
     public int decode(DecodeIterator iter, LocalElementSetDefDb localSetDb);
 
     /**
-     * Checks the presence of the Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Information presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -246,9 +247,9 @@ public interface ElementList extends XMLDecoder
     public boolean checkHasInfo();
 
     /**
-     * Checks the presence of the Standard Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Standard Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -257,9 +258,9 @@ public interface ElementList extends XMLDecoder
     public boolean checkHasStandardData();
 
     /**
-     * Checks the presence of the Set Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Set Id presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -268,9 +269,9 @@ public interface ElementList extends XMLDecoder
     public boolean checkHasSetId();
 
     /**
-     * Checks the presence of the Set Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Set Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -279,36 +280,36 @@ public interface ElementList extends XMLDecoder
     public boolean checkHasSetData();
 
     /**
-     * Applies the Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Information presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasInfo();
 
     /**
-     * Applies the Standard Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Standard Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasStandardData();
 
     /**
-     * Applies the Set Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Set Id presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSetId();
 
     /**
-     * Applies the Set Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Set Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/EncodeIterator.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/EncodeIterator.java
@@ -45,8 +45,9 @@ import com.thomsonreuters.upa.transport.TransportBuffer;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * //Create EncodeIterator using CodecFactory
- * EncodeIterator encIter = CodecFactory.createEncodeIterator()}; 
+ * EncodeIterator encIter = CodecFactory.createEncodeIterator(); 
  * 
  * //Clear iterator 
  * clear();
@@ -61,6 +62,7 @@ import com.thomsonreuters.upa.transport.TransportBuffer;
  * }
  * 
  * //Do encoding using iterator
+ * }
  * </pre>
  * 
  * </li>

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/FieldList.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/FieldList.java
@@ -38,7 +38,6 @@ import com.thomsonreuters.upa.codec.Buffer;
  * 
  * <pre>
  * 
- * 
  * FieldList fieldList = CodecFactory.createFieldList();
  * 
  * // create a single FieldEntry and reuse for each entry
@@ -257,9 +256,9 @@ public interface FieldList extends XMLDecoder
     public int decode(DecodeIterator iter, LocalFieldSetDefDb localSetDb);
 
     /**
-     * Checks the presence of the Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Information presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -268,9 +267,9 @@ public interface FieldList extends XMLDecoder
     public boolean checkHasInfo();
 
     /**
-     * Checks the presence of the Standard Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Standard Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -279,9 +278,9 @@ public interface FieldList extends XMLDecoder
     public boolean checkHasStandardData();
 
     /**
-     * Checks the presence of the Set Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Set Id presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -290,9 +289,9 @@ public interface FieldList extends XMLDecoder
     public boolean checkHasSetId();
 
     /**
-     * Checks the presence of the Set Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Set Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -301,36 +300,36 @@ public interface FieldList extends XMLDecoder
     public boolean checkHasSetData();
 
     /**
-     * Applies the Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Information presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasInfo();
 
     /**
-     * Applies the Standard Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Standard Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasStandardData();
 
     /**
-     * Applies the Set Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Set Id presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSetId();
 
     /**
-     * Applies the Set Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Set Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/FilterEntry.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/FilterEntry.java
@@ -94,9 +94,9 @@ public interface FilterEntry
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -105,9 +105,9 @@ public interface FilterEntry
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Container Type presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Container Type presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -116,18 +116,18 @@ public interface FilterEntry
     public boolean checkHasContainerType();
 
     /**
-     * Applies the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Container Type presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Container Type presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/FilterList.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/FilterList.java
@@ -256,9 +256,9 @@ public interface FilterList extends XMLDecoder
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the Per Entry Permission presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Per Entry Permission presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -267,9 +267,9 @@ public interface FilterList extends XMLDecoder
     public boolean checkHasPerEntryPermData();
 
     /**
-     * Checks the presence of the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Total Count Hint presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -278,18 +278,18 @@ public interface FilterList extends XMLDecoder
     public boolean checkHasTotalCountHint();
 
     /**
-     * Applies the Per Entry Permission presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Per Entry Permission presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasPerEntryPermData();
 
     /**
-     * Applies the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Total Count Hint presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/GenericMsg.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/GenericMsg.java
@@ -22,9 +22,9 @@ import com.thomsonreuters.upa.codec.Buffer;
 public interface GenericMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -33,9 +33,9 @@ public interface GenericMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Permission Expression presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -44,9 +44,9 @@ public interface GenericMsg extends Msg
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -55,9 +55,9 @@ public interface GenericMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -66,9 +66,9 @@ public interface GenericMsg extends Msg
     public boolean checkHasSeqNum();
 
     /**
-     * Checks the presence of the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Part Number presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -77,9 +77,9 @@ public interface GenericMsg extends Msg
     public boolean checkHasPartNum();
 
     /**
-     * Checks the presence of the Message Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Complete indication flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -88,9 +88,9 @@ public interface GenericMsg extends Msg
     public boolean checkMessageComplete();
 
     /**
-     * Checks the presence of the Secondary Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Secondary Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -99,63 +99,62 @@ public interface GenericMsg extends Msg
     public boolean checkHasSecondarySeqNum();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Permission Expression presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasSeqNum();
 
     /**
-     * Applies the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Part Number presence flag.
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPartNum();
 
     /**
-     * Applies the Message Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Complete indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyMessageComplete();
 
     /**
-     * Applies the Secondary Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Secondary Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/Map.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/Map.java
@@ -295,9 +295,9 @@ public interface Map extends XMLDecoder
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the local Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the local Set Definition presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -306,9 +306,9 @@ public interface Map extends XMLDecoder
     public boolean checkHasSetDefs();
 
     /**
-     * Checks the presence of the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Summary Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -317,9 +317,9 @@ public interface Map extends XMLDecoder
     public boolean checkHasSummaryData();
 
     /**
-     * Checks the presence of the Per Entry Permission presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Per Entry Permission presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -328,9 +328,9 @@ public interface Map extends XMLDecoder
     public boolean checkHasPerEntryPermData();
 
     /**
-     * Checks the presence of the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Total Count Hint presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -339,9 +339,9 @@ public interface Map extends XMLDecoder
     public boolean checkHasTotalCountHint();
 
     /**
-     * Checks the presence of the Key Field Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Key Field Id presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -350,45 +350,45 @@ public interface Map extends XMLDecoder
     public boolean checkHasKeyFieldId();
 
     /**
-     * Applies the local Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the local Set Definition presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSetDefs();
 
     /**
-     * Applies the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Summary Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSummaryData();
 
     /**
-     * Applies the Per Entry Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Per Entry Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasPerEntryPermData();
 
     /**
-     * Applies the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Total Count Hint presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasTotalCountHint();
 
     /**
-     * Applies the Key Field Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Key Field Id presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/MapEntry.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/MapEntry.java
@@ -565,9 +565,9 @@ public interface MapEntry
     public int decode(DecodeIterator iter, Object keyData);
 
     /**
-     * Checks the presence of the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -576,9 +576,9 @@ public interface MapEntry
     public boolean checkHasPermData();
 
     /**
-     * Applies the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/MsgKey.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/MsgKey.java
@@ -14,9 +14,9 @@ import com.thomsonreuters.upa.codec.Buffer;
 public interface MsgKey
 {
     /**
-     * Checks the presence of the Service Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Service Id presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -26,9 +26,8 @@ public interface MsgKey
     public boolean checkHasServiceId();
 
     /**
-     * Checks the presence of the Name presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Name presence flag.
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -37,9 +36,9 @@ public interface MsgKey
     public boolean checkHasName();
 
     /**
-     * Checks the presence of the Name Type presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Name Type presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -48,9 +47,9 @@ public interface MsgKey
     public boolean checkHasNameType();
 
     /**
-     * Checks the presence of the Filter presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Filter presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -59,9 +58,9 @@ public interface MsgKey
     public boolean checkHasFilter();
 
     /**
-     * Checks the presence of the Identifier presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Identifier presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -70,9 +69,9 @@ public interface MsgKey
     public boolean checkHasIdentifier();
 
     /**
-     * Checks the presence of the Attribute presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Attribute presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -81,54 +80,54 @@ public interface MsgKey
     public boolean checkHasAttrib();
 
     /**
-     * Applies the Service Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Service Id presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasServiceId();
 
     /**
-     * Applies the Name presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Name presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasName();
 
     /**
-     * Applies the Name Type presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Name Type presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasNameType();
 
     /**
-     * Applies the Filter presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Filter presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasFilter();
 
     /**
-     * Applies the Identifier presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Identifier presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasIdentifier();
 
     /**
-     * Applies the Attribute presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Attribute presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/PostMsg.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/PostMsg.java
@@ -20,9 +20,9 @@ import com.thomsonreuters.upa.codec.Buffer;
 public interface PostMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -31,9 +31,9 @@ public interface PostMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Post Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post Id presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -42,9 +42,9 @@ public interface PostMsg extends Msg
     public boolean checkHasPostId();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -53,9 +53,9 @@ public interface PostMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -64,9 +64,9 @@ public interface PostMsg extends Msg
     public boolean checkHasSeqNum();
 
     /**
-     * Checks the presence of the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Part Number presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -75,9 +75,9 @@ public interface PostMsg extends Msg
     public boolean checkHasPartNum();
 
     /**
-     * Checks the presence of the Post Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post Complete indication flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -86,9 +86,9 @@ public interface PostMsg extends Msg
     public boolean checkPostComplete();
 
     /**
-     * Checks the presence of the Acknowledgment indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Acknowledgment indication flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -97,9 +97,9 @@ public interface PostMsg extends Msg
     public boolean checkAck();
 
     /**
-     * Checks the presence of the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Permission Expression presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -108,9 +108,9 @@ public interface PostMsg extends Msg
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Post User Rights presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post User Rights presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -119,81 +119,81 @@ public interface PostMsg extends Msg
     public boolean checkHasPostUserRights();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Post Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post Id presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPostId();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Sequence Number presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasSeqNum();
 
     /**
-     * Applies the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Part Number presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPartNum();
 
     /**
-     * Applies the Post Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post Complete indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyPostComplete();
 
     /**
-     * Applies the Acknowledgment indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Acknowledgment indication flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyAck();
 
     /**
-     * Applies the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Permission Expression presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Post User Rights presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post User Rights presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/RealHints.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/RealHints.java
@@ -11,6 +11,7 @@ package com.thomsonreuters.upa.codec;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * if ({@link Real#hint()} < {@link #FRACTION_1})
  * {
  *      outputValue = Real.value()*(pow(10,(Real.hint() - {@link #EXPONENT0})));
@@ -18,6 +19,7 @@ package com.thomsonreuters.upa.codec;
  * else
  * {
  *      outputValue = Real.value()*(pow(2,(Real.hint() - {@link #FRACTION_1})));
+ * }
  * }
  * </pre>
  * </li>
@@ -29,6 +31,7 @@ package com.thomsonreuters.upa.codec;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * if (inputHint < {@link #FRACTION_1})
  * {
  *      Real.value = (inputValue)/(pow(10,(inputHint - {@link #EXPONENT0})));
@@ -36,6 +39,7 @@ package com.thomsonreuters.upa.codec;
  * else
  * {
  *      Real.value = (inputValue)/(pow(2,(inputHint - {@link #FRACTION_1})));
+ * }
  * }
  * </pre>
  * </li>

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/RefreshMsg.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/RefreshMsg.java
@@ -45,9 +45,9 @@ import com.thomsonreuters.upa.codec.State;
 public interface RefreshMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -56,9 +56,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -67,10 +67,10 @@ public interface RefreshMsg extends Msg
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
      * 
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
+     *
      * @see Msg#flags()
      * 
      * @return true - if exists; false if does not exist.
@@ -78,9 +78,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Sequence Number presence flag.
+     *
+     * <p>* Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -89,9 +89,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasSeqNum();
 
     /**
-     * Checks the presence of the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Part Number presence flag.
+     *
+     * <p>* Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -100,9 +100,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasPartNum();
 
     /**
-     * Checks the presence of the Solicited indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Solicited indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -111,9 +111,9 @@ public interface RefreshMsg extends Msg
     public boolean checkSolicited();
 
     /**
-     * Checks the presence of the Refresh Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Refresh Complete indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -122,9 +122,9 @@ public interface RefreshMsg extends Msg
     public boolean checkRefreshComplete();
 
     /**
-     * Checks the presence of the Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -133,9 +133,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasQos();
 
     /**
-     * Checks the presence of the Clear Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Clear Cache indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -144,9 +144,9 @@ public interface RefreshMsg extends Msg
     public boolean checkClearCache();
 
     /**
-     * Checks the presence of the Do Not Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Do Not Cache indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -155,9 +155,9 @@ public interface RefreshMsg extends Msg
     public boolean checkDoNotCache();
 
     /**
-     * Checks the presence of the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -166,9 +166,9 @@ public interface RefreshMsg extends Msg
     public boolean checkPrivateStream();
 
     /**
-     * Checks the presence of the Post User Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post User Information presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -177,9 +177,9 @@ public interface RefreshMsg extends Msg
     public boolean checkHasPostUserInfo();
 
     /**
-     * Checks the presence of the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -188,117 +188,117 @@ public interface RefreshMsg extends Msg
     public boolean checkQualifiedStream();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Sequence Number presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasSeqNum();
 
     /**
-     * Applies the Part Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Part Number presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPartNum();
 
     /**
-     * Applies the Solicited indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Solicited indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applySolicited();
 
     /**
-     * Applies the Refresh Complete indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Refresh Complete indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyRefreshComplete();
 
     /**
-     * Applies the Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasQos();
 
     /**
-     * Applies the Clear Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Clear Cache indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyClearCache();
 
     /**
-     * Applies the Do Not Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Do Not Cache indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyDoNotCache();
 
     /**
-     * Applies the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/
     public void applyPrivateStream();
 
     /**
-     * Applies the Post User Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post User Information presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPostUserInfo();
 
     /**
-     * Applies the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/RequestMsg.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/RequestMsg.java
@@ -31,9 +31,9 @@ import com.thomsonreuters.upa.codec.Qos;
 public interface RequestMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -42,9 +42,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Priority presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Priority presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -53,9 +53,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasPriority();
 
     /**
-     * Checks the presence of the Streaming indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Streaming indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -64,9 +64,9 @@ public interface RequestMsg extends Msg
     public boolean checkStreaming();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -75,9 +75,9 @@ public interface RequestMsg extends Msg
     public boolean checkMsgKeyInUpdates();
 
     /**
-     * Checks the presence of the Conflation Info presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Conflation Info presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -86,9 +86,9 @@ public interface RequestMsg extends Msg
     public boolean checkConfInfoInUpdates();
 
     /**
-     * Checks the presence of the No Refresh indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the No Refresh indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -97,9 +97,9 @@ public interface RequestMsg extends Msg
     public boolean checkNoRefresh();
 
     /**
-     * Checks the presence of the Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -108,9 +108,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasQos();
 
     /**
-     * Checks the presence of the Worst Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Worst Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -119,9 +119,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasWorstQos();
 
     /**
-     ** Checks the presence of the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     ** Checks the presence of the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      ** 
@@ -130,9 +130,9 @@ public interface RequestMsg extends Msg
     public boolean checkPrivateStream();
 
     /**
-     * Checks the presence of the Pause indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Pause indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -141,9 +141,9 @@ public interface RequestMsg extends Msg
     public boolean checkPause();
 
     /**
-     * Checks the presence of the View indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the View indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -152,9 +152,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasView();
 
     /**
-     * Checks the presence of the Batch indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Batch indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -163,9 +163,9 @@ public interface RequestMsg extends Msg
     public boolean checkHasBatch();
 
     /**
-     ** Checks the presence of the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     ** Checks the presence of the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      ** 
@@ -174,117 +174,117 @@ public interface RequestMsg extends Msg
     public boolean checkQualifiedStream();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Priority presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Priority presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPriority();
 
     /**
-     * Applies the Streaming indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Streaming indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyStreaming();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyMsgKeyInUpdates();
 
     /**
-     * Applies the Conflation Information in Updates indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Conflation Information in Updates indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyConfInfoInUpdates();
 
     /**
-     * Applies the No Refresh indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the No Refresh indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyNoRefresh();
 
     /**
-     * Applies the Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasQos();
 
     /**
-     * Applies the Worst Quality of Service presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Worst Quality of Service presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasWorstQos();
 
     /**
-     ** Applies the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     ** Applies the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/
     public void applyPrivateStream();
 
     /**
-     * Applies the Pause indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Pause indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyPause();
 
     /**
-     * Applies the View indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the View indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasView();
 
     /**
-     * Applies the Batch indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Batch indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasBatch();
 
     /**
-     ** Applies the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     ** Applies the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/Series.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/Series.java
@@ -254,9 +254,9 @@ public interface Series extends XMLDecoder
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Set Definition presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -265,9 +265,9 @@ public interface Series extends XMLDecoder
     public boolean checkHasSetDefs();
 
     /**
-     * Checks the presence of the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Summary Data presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -276,9 +276,9 @@ public interface Series extends XMLDecoder
     public boolean checkHasSummaryData();
 
     /**
-     * Checks the presence of the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Total Count Hint presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -287,27 +287,27 @@ public interface Series extends XMLDecoder
     public boolean checkHasTotalCountHint();
 
     /**
-     * Applies the local Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the local Set Definition presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSetDefs();
 
     /**
-     * Applies the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Summary Data presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSummaryData();
 
     /**
-     * Applies the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Total Count Hint presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/StatusMsg.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/StatusMsg.java
@@ -20,9 +20,9 @@ import com.thomsonreuters.upa.codec.State;
 public interface StatusMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -31,9 +31,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -42,9 +42,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -53,9 +53,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the Group Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Group Id presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -64,9 +64,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasGroupId();
 
     /**
-     * Checks the presence of the State presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the State presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -75,9 +75,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasState();
 
     /**
-     * Checks the presence of the Clear Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Clear Cache indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -86,9 +86,9 @@ public interface StatusMsg extends Msg
     public boolean checkClearCache();
 
     /**
-     * Checks the presence of the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -97,9 +97,9 @@ public interface StatusMsg extends Msg
     public boolean checkPrivateStream();
 
     /**
-     * Checks the presence of the Post User Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post User Information presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -108,9 +108,9 @@ public interface StatusMsg extends Msg
     public boolean checkHasPostUserInfo();
 
     /**
-     * Checks the presence of the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -119,81 +119,81 @@ public interface StatusMsg extends Msg
     public boolean checkQualifiedStream();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the Group Id presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Group Id presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasGroupId();
 
     /**
-     * Applies the State presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the State presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasState();
 
     /**
-     * Applies the Clear Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Clear Cache indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyClearCache();
 
     /**
-     ** Applies the Private Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     ** Applies the Private Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/
     public void applyPrivateStream();
 
     /**
-     * Applies the Post User Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post User Information presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPostUserInfo();
 
     /**
-     * Applies the Qualified Stream indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Qualified Stream indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      **/

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/UpdateMsg.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/UpdateMsg.java
@@ -23,9 +23,9 @@ import com.thomsonreuters.upa.rdm.UpdateEventTypes;
 public interface UpdateMsg extends Msg
 {
     /**
-     * Checks the presence of the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -34,9 +34,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasExtendedHdr();
 
     /**
-     * Checks the presence of the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -45,9 +45,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasPermData();
 
     /**
-     * Checks the presence of the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -56,9 +56,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasMsgKey();
 
     /**
-     * Checks the presence of the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Sequence Number presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -67,9 +67,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasSeqNum();
 
     /**
-     * Checks the presence of the Conflation Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Conflation Information presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -78,9 +78,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasConfInfo();
 
     /**
-     * Checks the presence of the Do Not Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Do Not Cache indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -89,9 +89,9 @@ public interface UpdateMsg extends Msg
     public boolean checkDoNotCache();
 
     /**
-     * Checks the presence of the Do Not Conflate indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Do Not Conflate indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -100,9 +100,9 @@ public interface UpdateMsg extends Msg
     public boolean checkDoNotConflate();
 
     /**
-     * Checks the presence of the Do Not Ripple indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Do Not Ripple indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -111,9 +111,9 @@ public interface UpdateMsg extends Msg
     public boolean checkDoNotRipple();
 
     /**
-     * Checks the presence of the Post User Information presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Post User Information presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -122,9 +122,9 @@ public interface UpdateMsg extends Msg
     public boolean checkHasPostUserInfo();
 
     /**
-     * Checks the presence of the Discardable presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link Msg#flags()}.
+     * Checks the presence of the Discardable presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link Msg#flags()}.
      * 
      * @see Msg#flags()
      * 
@@ -133,90 +133,90 @@ public interface UpdateMsg extends Msg
     public boolean checkDiscardable();
 
     /**
-     * Applies the Extended Header presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Extended Header presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasExtendedHdr();
 
     /**
-     * Applies the Permission Expression presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Permission Expression presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPermData();
 
     /**
-     * Applies the Message Key presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Message Key presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasMsgKey();
 
     /**
-     * Applies the Sequence Number presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Sequence Number presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasSeqNum();
 
     /**
-     * Applies the Conflation Info presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Conflation Info presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasConfInfo();
 
     /**
-     * Applies the Do Not Cache indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Do Not Cache indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyDoNotCache();
 
     /**
-     * Applies the Do Not Conflate indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Do Not Conflate indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyDoNotConflate();
 
     /**
-     * Applies the Do Not Ripple indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Do Not Ripple indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyDoNotRipple();
 
     /**
-     * Applies the Post User Info presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Post User Info presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */
     public void applyHasPostUserInfo();
 
     /**
-     * Applies the Discardable presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link Msg#flags(int)}.
+     * Applies the Discardable presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link Msg#flags(int)}.
      * 
      * @see Msg#flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/Vector.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/Vector.java
@@ -144,6 +144,7 @@ import com.thomsonreuters.upa.codec.Buffer;
  * <li class="blockList">
  * 
  * <pre>
+ * {@code
  * //decode contents into the vector
  * if((retVal = vector.decode(decIter) >= CodecReturnCodes.SUCCESS)
  * {
@@ -180,6 +181,7 @@ import com.thomsonreuters.upa.codec.Buffer;
  * else
  * {
  *      //decoding failure tends to be unrecoverable
+ * }
  * }
  * </pre>
  * 
@@ -277,9 +279,9 @@ public interface Vector extends XMLDecoder
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the local Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the local Set Definition presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -288,9 +290,9 @@ public interface Vector extends XMLDecoder
     public boolean checkHasSetDefs();
 
     /**
-     * Checks the presence of the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Summary Data presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -299,9 +301,9 @@ public interface Vector extends XMLDecoder
     public boolean checkHasSummaryData();
 
     /**
-     * Checks the presence of the Per Entry Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Per Entry Permission Data presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -310,9 +312,9 @@ public interface Vector extends XMLDecoder
     public boolean checkHasPerEntryPermData();
 
     /**
-     * Checks the presence of the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Total Count Hint presence flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -321,9 +323,9 @@ public interface Vector extends XMLDecoder
     public boolean checkHasTotalCountHint();
 
     /**
-     * Checks the presence of the Supports Sorting indication flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Supports Sorting indication flag.
+     *
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -332,45 +334,45 @@ public interface Vector extends XMLDecoder
     public boolean checkSupportsSorting();
 
     /**
-     * Applies the local Set Definition presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the local Set Definition presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSetDefs();
 
     /**
-     * Applies the Summary Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Summary Data presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasSummaryData();
 
     /**
-     * Applies the Per Entry Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Per Entry Permission Data presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasPerEntryPermData();
 
     /**
-     * Applies the Total Count Hint presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Total Count Hint presence flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */
     public void applyHasTotalCountHint();
 
     /**
-     * Applies the Supports Sorting indication flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Supports Sorting indication flag.
+     *
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/VectorEntry.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/codec/VectorEntry.java
@@ -89,9 +89,9 @@ public interface VectorEntry
     public int decode(DecodeIterator iter);
 
     /**
-     * Checks the presence of the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-get via {@link #flags()}.
+     * Checks the presence of the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-get via {@link #flags()}.
      * 
      * @see #flags()
      * 
@@ -100,9 +100,9 @@ public interface VectorEntry
     public boolean checkHasPermData();
 
     /**
-     * Applies the Permission Data presence flag.<br />
-     * <br />
-     * Flags may also be bulk-set via {@link #flags(int)}.
+     * Applies the Permission Data presence flag.
+     * 
+     * <p>Flags may also be bulk-set via {@link #flags(int)}.
      * 
      * @see #flags(int)
      */

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/valueadd/cache/PayloadEntry.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/valueadd/cache/PayloadEntry.java
@@ -41,7 +41,7 @@ public interface PayloadEntry
 	 * OMM container in the message payload is applied to the cache entry
 	 * following the OMM rules of the message and the container type.
 	 *
-	 * When this function returns an error (< CodecReturnCodes.SUCCESS), some 
+	 * When this function returns an error (&lt; CodecReturnCodes.SUCCESS), some 
 	 * or all of the data could not be cached. Some errors returned by this function
 	 * can be handled as warnings, depending on application requirements. When
 	 * the function returns an error code, the CacheError errorId can be
@@ -56,7 +56,7 @@ public interface PayloadEntry
 	 * @param msg The partially decoded message structure
 	 * @param error The error information structure will be populated if the
 	 * payload data from the message could not be written to the cache entry
-	 * @return Returns failure codes (< CodecReturnCodes.SUCCESS) if the data could not be applied to the cache entry
+	 * @return Returns failure codes (&lt; CodecReturnCodes.SUCCESS) if the data could not be applied to the cache entry
 	 */
 	public int apply( DecodeIterator dIter, Msg msg, CacheError error );
 
@@ -85,7 +85,7 @@ public interface PayloadEntry
 	 * single part retrieval.
 	 * @param error The error in formation structure will be populated if payload
 	 * entry cache data could not be retrieved.
-	 * @return Failure codes (< CodecReturnCodes.SUCCESS) if data could not be
+	 * @return Failure codes (&lt; CodecReturnCodes.SUCCESS) if data could not be
 	 * retrieved from the container.
 	 * - CodecReturnCodes.BUFFER_TOO_SMALL indicates that the buffer size should be
 	 * increased in order to retrieve the data from the entry (single part or multi-part). 

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/valueadd/domainrep/rdm/dictionary/DictionaryRefresh.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/valueadd/domainrep/rdm/dictionary/DictionaryRefresh.java
@@ -69,7 +69,7 @@ public interface DictionaryRefresh extends DictionaryMsg
 
     /**
      * Applies the flag for presence of the dictionaryId, version, and type
-     * members .<br />
+     * members.<br>
      * 
      * This flag is typically not used as this information is automatically
      * added by the encode method when appropriate.
@@ -197,7 +197,7 @@ public interface DictionaryRefresh extends DictionaryMsg
     public Buffer dataBody();
 
     /**
-     * This field is initialized with dictionary->minFid and after encoding each
+     * This field is initialized with dictionary-&gt;minFid and after encoding each
      * part, updated with the start Fid for next encoded part. When decoding,
      * this is not used.
      * 
@@ -206,7 +206,7 @@ public interface DictionaryRefresh extends DictionaryMsg
     public void startFid(int startFid);
 
     /**
-     * This field is initialized with dictionary->minFid and after encoding each
+     * This field is initialized with dictionary-&gt;minFid and after encoding each
      * part, updated with the start Fid for next encoded part. When decoding,
      * this is not used.
      * 

--- a/Java/Eta/Source/interface/com/thomsonreuters/upa/valueadd/domainrep/rdm/login/LoginSupportFeatures.java
+++ b/Java/Eta/Source/interface/com/thomsonreuters/upa/valueadd/domainrep/rdm/login/LoginSupportFeatures.java
@@ -42,15 +42,15 @@ public interface LoginSupportFeatures
     public int copy(LoginSupportFeatures destLoginSupportFeatures);
 
     /**
-     * Indicates whether the Provider supports Optimized Pause & Resume.
+     * Indicates whether the Provider supports Optimized Pause &amp; Resume.
      * 
      * @return supportOptimizedPauseResume. 1 - if provider supports Optimized
-     *         Pause & Resume. 0 - if not.
+     *         Pause &amp; Resume. 0 - if not.
      */
     public long supportOptimizedPauseResume();
 
     /**
-     * Indicates whether the Provider supports Optimized Pause & Resume.
+     * Indicates whether the Provider supports Optimized Pause &amp; Resume.
      * 
      * @param supportOptimizedPauseResume
      */

--- a/Java/Eta/Source/test/com/thomsonreuters/upa/test/network/replay/NetworkReplay.java
+++ b/Java/Eta/Source/test/com/thomsonreuters/upa/test/network/replay/NetworkReplay.java
@@ -28,7 +28,7 @@ public interface NetworkReplay
      * Parses a file containing network replay data, and returns the total
      * number of non-comment bytes read from the file.
      * 
-     * @param The name of the file to parse
+     * @param name The name of the file to parse
      * 
      * @return The total number of non-comment bytes read from the file
      * 
@@ -49,7 +49,7 @@ public interface NetworkReplay
      * the number of bytes remaining in the buffer, that is, dst.remaining(),
      * at the moment this method is invoked.
      * <p>
-     * Suppose that a byte sequence of length n is read, where 0 <= n <= r.
+     * Suppose that a byte sequence of length n is read, where 0 &lt;= n &lt;= r.
      * This byte sequence will be transferred into the buffer so that the first byte in the sequence
      * is at index p and the last byte is at index p + n - 1,
      * where p is the buffer's position at the moment this method is invoked.


### PR DESCRIPTION
This change makes the Elektron-SDK (java part) compile without problems on JDK8.

Only problems of type `ERROR` have been corrected, because such errors make the build stop, at least if you're using Maven. Problems of type `WARNING` haven't been touched, neither has spellings errors, typos, etc. The errors were all related to invalid html code which was silently accepted in Javadoc compiler prior to JDK8, but which would now make a build fail.

Non-exhaustive list of what was changed:

- Changed literals `<`,  `>` and `&` to their html equivalents.
- `<li>` and `<ol>` isn't allowed inside a `<p>` tag.
- Use of `<br />` is illegal in html.
- Use of Javadoc markup (i.e. `{@xxx ...}`) was possible inside a `<pre>`  tag prior to Java 8. That should never have been the case, and unfortunately Oracle has now closed this 'loophole' thereby making such constructs invalid.

I _haven't_ made an effort to change syntax which isn't invalid, but merely discouraged. 
Example:

```
/**
 *  Lorem ipsum dolor sit amet.
 *
 * <p>
 * Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
 * magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
 * nisi ut aliquip ex ea commodo consequat. 
 * </p>
 */
```

instead of the more correct form:

```
/**
 *  Lorem ipsum dolor sit amet.
 *
 * <p>
 * Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
 * magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
 * nisi ut aliquip ex ea commodo consequat. 
 */
```

No point in changing something that still works.


/Lars