### PR TITLE
Corrected Javadoc errors in EMA : Login.java

### DIFF
--- a/Java/Ema/Src/main/java/interface/com/thomsonreuters/ema/domain/login/Login.java
+++ b/Java/Ema/Src/main/java/interface/com/thomsonreuters/ema/domain/login/Login.java
@@ -835,7 +835,7 @@ public interface Login
 		public boolean supportViewRequests();
 
 		/**
-		* @throw OmmInvalidUsageException if hasSupportStandby() returns false.
+		* @throws OmmInvalidUsageException if hasSupportStandby() returns false.
 		* @return true if Warm Standby is supported, false if not supported.
 		*/
 		public boolean supportStandby();
@@ -903,14 +903,14 @@ public interface Login
                    
         /**
          * Sets authenticationErrorCode.
-         * @param value long representing authenticationErrorCode.
+         * @param authenticationErrorCode
          * @return reference to this object.
          */
         public LoginStatus authenticationErrorCode( long authenticationErrorCode );
                    
         /**
          * Sets authenticationErrorText.
-         * @param value String representing authenticationErrorText.
+         * @param authenticationErrorText
          * @return reference to this object.
          */
         public LoginStatus authenticationErrorText( String authenticationErrorText );


### PR DESCRIPTION
Corrected Javadoc errors in new file, `Login.java`, introduced in EMA on 22 Mar 2017.

The errors prevent successful build with JDK8.