### PR TITLE
Java-Eta : Patterns created for each instance rather than once

### DIFF
--- a/Java/Eta/Core/src/main/java/com/thomsonreuters/proxy/authentication/NtlmAuthenticationScheme.java
+++ b/Java/Eta/Core/src/main/java/com/thomsonreuters/proxy/authentication/NtlmAuthenticationScheme.java
@@ -20,8 +20,8 @@ class NtlmAuthenticationScheme implements IAuthenticationScheme
     private static final String[] RequiredCredentials = {
         CredentialName.DOMAIN, CredentialName.USERNAME, CredentialName.PASSWORD, CredentialName.LOCAL_HOSTNAME };
     private final NTLMEngineImpl _ntlmEgine = new NTLMEngineImpl();
-    private final Pattern _proxyAuthenticatePattern = Pattern.compile("Proxy-Authenticate: " + NTLM_RESPONSE_PREFIX + "(\\S+)");
-    private final Pattern _wwwAuthenticatePattern = Pattern.compile("WWW-Authenticate: " + NTLM_RESPONSE_PREFIX + "(\\S+)");
+    private static final Pattern PROXY_AUTHENTICATE_PATTERN = Pattern.compile("Proxy-Authenticate: " + NTLM_RESPONSE_PREFIX + "(\\S+)");
+    private static final Pattern WWW_AUTHENTICATE_PATTERN = Pattern.compile("WWW-Authenticate: " + NTLM_RESPONSE_PREFIX + "(\\S+)");
 
     private int ntlmResponseCount = 0;
     boolean stopScheme = false;
@@ -202,11 +202,11 @@ class NtlmAuthenticationScheme implements IAuthenticationScheme
 
         if (httpResponseCode == 407)
         {
-            matcher = _proxyAuthenticatePattern.matcher(response);
+            matcher = PROXY_AUTHENTICATE_PATTERN.matcher(response);
         }
         else
         {
-            matcher = _wwwAuthenticatePattern.matcher(response);
+            matcher = WWW_AUTHENTICATE_PATTERN.matcher(response);
         }
 
         if (matcher.find() && matcher.groupCount() >= 1)

--- a/Java/Eta/Core/src/main/java/com/thomsonreuters/proxy/authentication/ProxyAuthenticatorImpl.java
+++ b/Java/Eta/Core/src/main/java/com/thomsonreuters/proxy/authentication/ProxyAuthenticatorImpl.java
@@ -14,11 +14,11 @@ class ProxyAuthenticatorImpl implements IProxyAuthenticator
     private static final String END_OF_CHUNK = "\r\n\r\n";
 
     private IAuthenticationScheme _authScheme;
-    private final Pattern _httpVersionPattern = Pattern.compile("^\\s*HTTP/1.. (\\d+)");
-    private final Pattern _proxyAuthenticatePattern = Pattern.compile("Proxy-[a|A]uthenticate: (\\w+)");
-    private final Pattern _wwwAuthenticatePattern = Pattern.compile("WWW-[a|A]uthenticate: (\\w+)");
-    private final Pattern _proxyConnectionClosePattern = Pattern.compile("Proxy-[c|C]onnection: close");
-    private final Pattern _connectionClosePattern = Pattern.compile("Connection: [c|C]lose");
+    private static final Pattern HTTP_VERSION_PATTERN = Pattern.compile("^\\s*HTTP/1.. (\\d+)");
+    private static final Pattern PROXY_AUTHENTICATE_PATTERN = Pattern.compile("Proxy-[a|A]uthenticate: (\\w+)");
+    private static final Pattern WWW_AUTHENTICATE_PATTERN = Pattern.compile("WWW-[a|A]uthenticate: (\\w+)");
+    private static final Pattern PROXY_CONNECTION_CLOSE_PATTERN = Pattern.compile("Proxy-[c|C]onnection: close");
+    private static final Pattern CONNECTION_CLOSE_PATTERN = Pattern.compile("Connection: [c|C]lose");
 	
     boolean negotiateHasFailed = false;
     boolean kerberosHasFailed = false;
@@ -188,11 +188,11 @@ class ProxyAuthenticatorImpl implements IProxyAuthenticator
 
         if (httpResponseCode == 407)
         {
-            matcher = _proxyAuthenticatePattern.matcher(response);
+            matcher = PROXY_AUTHENTICATE_PATTERN.matcher(response);
         }
         else
         {
-            matcher = _wwwAuthenticatePattern.matcher(response);
+            matcher = WWW_AUTHENTICATE_PATTERN.matcher(response);
         }
 
         while (matcher.find())
@@ -208,13 +208,13 @@ class ProxyAuthenticatorImpl implements IProxyAuthenticator
 
     private boolean responseContainsProxyClose(String response)
     {
-        Matcher matcher = _proxyConnectionClosePattern.matcher(response);
+        Matcher matcher = PROXY_CONNECTION_CLOSE_PATTERN.matcher(response);
         return matcher.find();
     }
 	
     private boolean responseContainsConnectionClose(String response)
     {
-        Matcher matcher = _connectionClosePattern.matcher(response);
+        Matcher matcher = CONNECTION_CLOSE_PATTERN.matcher(response);
         return matcher.find();
     }
 
@@ -239,7 +239,7 @@ class ProxyAuthenticatorImpl implements IProxyAuthenticator
             {
                 for (String chunk : responseChunks)
                 {
-                    Matcher matcher = _httpVersionPattern.matcher(chunk);
+                    Matcher matcher = HTTP_VERSION_PATTERN.matcher(chunk);
 
                     if (matcher.find() && matcher.groupCount() >= 1)
                     {

--- a/Java/Eta/Core/src/main/java/com/thomsonreuters/upa/codec/DateImpl.java
+++ b/Java/Eta/Core/src/main/java/com/thomsonreuters/upa/codec/DateImpl.java
@@ -14,15 +14,16 @@ class DateImpl implements Date
     int _year;
     int _format = DateTimeStringFormatTypes.STR_DATETIME_RSSL;
     
-    private String[] _months = { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
+    // English 3-letter month names
+    protected static final String[] MONTHS_EN = { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
 
     // for value(String) method
     private String trimmedVal;
-    private Pattern datePattern1 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)");
-    private Pattern datePattern2 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)");
-    private Pattern datePattern3 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)");
-    private Pattern datePattern4 = Pattern.compile("(\\d+)-(\\d+)-(\\d+)"); // ISO8601 date 'YYYY-MM-DD'
-    private Pattern datePattern5 = Pattern.compile("(\\d+)"); // ISO8601 date 'YYYYMMDD'
+    private static final Pattern DATE_PATTERN_1 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)");
+    private static final Pattern DATE_PATTERN_2 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)");
+    private static final Pattern DATE_PATTERN_3 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)");
+    private static final Pattern DATE_PATTERN_4 = Pattern.compile("(\\d+)-(\\d+)-(\\d+)"); // ISO8601 date 'YYYY-MM-DD'
+    private static final Pattern DATE_PATTERN_5 = Pattern.compile("(\\d+)"); // ISO8601 date 'YYYYMMDD'
     
     // Converts RsslDate to string in ISO8601 'YYYY-MM-DD' format (e.g. 2003-06-01).
     public String toStringIso8601()
@@ -84,7 +85,7 @@ class DateImpl implements Date
 
         if (_month != 0)
         {
-            retStr.append(String.format("%s ",_months[_month - 1]));
+            retStr.append(String.format("%s ",MONTHS_EN[_month - 1]));
         }
         else
         {
@@ -275,7 +276,7 @@ class DateImpl implements Date
                 blank();
                 return CodecReturnCodes.SUCCESS;
             }
-            Matcher matcher = datePattern5.matcher(trimmedVal);
+            Matcher matcher = DATE_PATTERN_5.matcher(trimmedVal);
             if (matcher.matches() && matcher.groupCount() == 1)
             {	// ISO8601 date YYYYMMDD format.
             	
@@ -298,7 +299,7 @@ class DateImpl implements Date
             	return CodecReturnCodes.SUCCESS;
             }
             
-            matcher = datePattern4.matcher(trimmedVal);
+            matcher = DATE_PATTERN_4.matcher(trimmedVal);
             if (matcher.matches() && matcher.groupCount() == 3)
             {	// ISO8601 Date YYYY-MM-DD format.
                 int a = Integer.parseInt(matcher.group(1));
@@ -316,7 +317,7 @@ class DateImpl implements Date
                     return ret;  	
             	return CodecReturnCodes.SUCCESS;
             }
-            matcher = datePattern1.matcher(trimmedVal);
+            matcher = DATE_PATTERN_1.matcher(trimmedVal);
 
             if (matcher.matches() && matcher.groupCount() == 3)
             {
@@ -369,7 +370,7 @@ class DateImpl implements Date
 
             if (Character.isDigit(trimmedVal.charAt(3)))
             {
-                matcher = datePattern2.matcher(trimmedVal);
+                matcher = DATE_PATTERN_2.matcher(trimmedVal);
                 if (matcher.matches() && matcher.groupCount() == 3)
                 {
                     int a = Integer.parseInt(matcher.group(1));
@@ -425,7 +426,7 @@ class DateImpl implements Date
             }
             else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
             {
-                matcher = datePattern3.matcher(trimmedVal);
+                matcher = DATE_PATTERN_3.matcher(trimmedVal);
                 if (matcher.matches() && matcher.groupCount() == 3)
                 {
                     int a = Integer.parseInt(matcher.group(1));
@@ -479,7 +480,7 @@ class DateImpl implements Date
 
         for (i = 0; i < 12; i++)
         {
-            if (monthStr.equalsIgnoreCase(_months[i]))
+            if (monthStr.equalsIgnoreCase(MONTHS_EN[i]))
             {
                 month = i + 1;
                 break;

--- a/Java/Eta/Core/src/main/java/com/thomsonreuters/upa/codec/DateTimeImpl.java
+++ b/Java/Eta/Core/src/main/java/com/thomsonreuters/upa/codec/DateTimeImpl.java
@@ -1,5 +1,6 @@
 package com.thomsonreuters.upa.codec;
 
+import static com.thomsonreuters.upa.codec.DateImpl.MONTHS_EN;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
@@ -13,59 +14,58 @@ class DateTimeImpl implements DateTime
     
     private Calendar _calendar;
     private Matcher matcher;
-    private static String months[] = { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
     
     // for value(String) method
     private String trimmedVal;
 	
     // Date + time to milli
-    private Pattern datetimePattern1 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+)");  // m/d/y h:m:s:milli
-    private Pattern datetimePattern2 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");  // d my y h m s milli
-    private Pattern datetimePattern3 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");// d month y h m s milli
-    private Pattern datetimePattern4 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)"); //m/d/y h m s milli
-    private Pattern datetimePattern5 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+)"); // d m y h:m:s:milli
-    private Pattern datetimePattern6 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+)"); // d month year h:m:s:milli
+    private static final Pattern DATETIME_PATTERN_1 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+)");  // m/d/y h:m:s:milli
+    private static final Pattern DATETIME_PATTERN_2 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");  // d my y h m s milli
+    private static final Pattern DATETIME_PATTERN_3 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");// d month y h m s milli
+    private static final Pattern DATETIME_PATTERN_4 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)"); //m/d/y h m s milli
+    private static final Pattern DATETIME_PATTERN_5 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+)"); // d m y h:m:s:milli
+    private static final Pattern DATETIME_PATTERN_6 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+)"); // d month year h:m:s:milli
     
     // date + time to nano
-    private Pattern datetimePattern7 =
+    private static final Pattern DATETIME_PATTERN_7 =
             Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+):(\\d+):(\\d+)");  // m/d/y h:m:s:milli:micro:nano
-    private Pattern datetimePattern8 =
+    private static final Pattern DATETIME_PATTERN_8 =
             Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");  // d my y h m s milli micro nano
-    private Pattern datetimePattern9 =
+    private static final Pattern DATETIME_PATTERN_9 =
             Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");// d month y h m s milli micro nano
-    private Pattern datetimePattern10 =
+    private static final Pattern DATETIME_PATTERN_10 =
             Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)"); //m/d/y h m s milli micro nano
-    private Pattern datetimePattern11 =
+    private static final Pattern DATETIME_PATTERN_11 =
             Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+):(\\d+):(\\d+)"); // d m y h:m:s:milli:micro:nano
-    private Pattern datetimePattern12 =
+    private static final Pattern DATETIME_PATTERN_12 =
             Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+):(\\d+):(\\d+)"); // d month year h:m:s:milli:micro:nano
     
-    private Pattern datetimePattern13 =
+    private static final Pattern DATETIME_PATTERN_13 =
             Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+):(\\d+)");  // m/d/y h:m:s:milli:micro
-    private Pattern datetimePattern14 =
+    private static final Pattern DATETIME_PATTERN_14 =
             Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");  // d my y h m s milli micro 
-    private Pattern datetimePattern15 =
+    private static final Pattern DATETIME_PATTERN_15 =
             Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");// d month y h m s milli micro 
-    private Pattern datetimePattern16 =
+    private static final Pattern DATETIME_PATTERN_16 =
             Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)"); //m/d/y h m s milli micro 
-    private Pattern datetimePattern17 =
+    private static final Pattern DATETIME_PATTERN_17 =
             Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+):(\\d+)"); // d m y h:m:s:milli:micro
-    private Pattern datetimePattern18 =
+    private static final Pattern DATETIME_PATTERN_18 =
             Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+):(\\d+):(\\d+)"); // d month year h:m:s:milli:micro
     
-    private Pattern datetimePattern19 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+):(\\d+):(\\d+)");  // m/d/y h:m:s
-    private Pattern datetimePattern20 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");  // d my y h m s 
-    private Pattern datetimePattern21 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");// d month y h m s 
-    private Pattern datetimePattern22 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)"); //m/d/y h m s 
-    private Pattern datetimePattern23 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+)"); // d m y h:m:s
-    private Pattern datetimePattern24 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+)"); // d month year h:m:s
+    private static final Pattern DATETIME_PATTERN_19 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+):(\\d+):(\\d+)");  // m/d/y h:m:s
+    private static final Pattern DATETIME_PATTERN_20 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");  // d my y h m s 
+    private static final Pattern DATETIME_PATTERN_21 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");// d month y h m s 
+    private static final Pattern DATETIME_PATTERN_22 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)"); //m/d/y h m s 
+    private static final Pattern DATETIME_PATTERN_23 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+)"); // d m y h:m:s
+    private static final Pattern DATETIME_PATTERN_24 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+):(\\d+):(\\d+)"); // d month year h:m:s
     
-    private Pattern datetimePattern25 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+):(\\d+)");  // m/d/y h:m
-    private Pattern datetimePattern26 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");  // d my y h m  
-    private Pattern datetimePattern27 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");// d month y h m 
-    private Pattern datetimePattern28 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+)\\s(\\d+)"); //m/d/y h m  
-    private Pattern datetimePattern29 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+):(\\d+)"); // d m y h:m
-    private Pattern datetimePattern30 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+):(\\d+)"); // d month year h:m
+    private static final Pattern DATETIME_PATTERN_25 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+):(\\d+)");  // m/d/y h:m
+    private static final Pattern DATETIME_PATTERN_26 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");  // d my y h m  
+    private static final Pattern DATETIME_PATTERN_27 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");// d month y h m 
+    private static final Pattern DATETIME_PATTERN_28 = Pattern.compile("(\\d+)/(\\d+)/(\\d+)\\s(\\d+)\\s(\\d+)"); //m/d/y h m  
+    private static final Pattern DATETIME_PATTERN_29 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+):(\\d+)"); // d m y h:m
+    private static final Pattern DATETIME_PATTERN_30 = Pattern.compile("(\\d+)\\s(\\p{Alpha}+)\\s(\\d+)\\s(\\d+):(\\d+)"); // d month year h:m
  
     DateTimeImpl()
     {
@@ -123,7 +123,7 @@ class DateTimeImpl implements DateTime
     private int matchDTToMin(String value)
     {
         int ret = CodecReturnCodes.SUCCESS;
-        matcher = datetimePattern25.matcher(trimmedVal);
+        matcher = DATETIME_PATTERN_25.matcher(trimmedVal);
         if (matcher.matches())
         {
             int a = Integer.parseInt(matcher.group(1));
@@ -185,7 +185,7 @@ class DateTimeImpl implements DateTime
 
         if (Character.isDigit(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern26.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_26.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -247,7 +247,7 @@ class DateTimeImpl implements DateTime
         }
         else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern27.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_27.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -295,7 +295,7 @@ class DateTimeImpl implements DateTime
             }
         }
 
-        matcher = datetimePattern28.matcher(trimmedVal);
+        matcher = DATETIME_PATTERN_28.matcher(trimmedVal);
         if (matcher.matches())
         {
             int a = Integer.parseInt(matcher.group(1));
@@ -356,7 +356,7 @@ class DateTimeImpl implements DateTime
         }
         if (Character.isDigit(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern29.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_29.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -418,7 +418,7 @@ class DateTimeImpl implements DateTime
         }
         else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern30.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_30.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -475,7 +475,7 @@ class DateTimeImpl implements DateTime
     private int matchDTToSec(String value)
     {
         int ret = CodecReturnCodes.SUCCESS;
-        matcher = datetimePattern19.matcher(trimmedVal);
+        matcher = DATETIME_PATTERN_19.matcher(trimmedVal);
         if (matcher.matches())
         {
             int a = Integer.parseInt(matcher.group(1));
@@ -539,7 +539,7 @@ class DateTimeImpl implements DateTime
 
         if (Character.isDigit(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern20.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_20.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -603,7 +603,7 @@ class DateTimeImpl implements DateTime
         }
         else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern21.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_21.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -653,7 +653,7 @@ class DateTimeImpl implements DateTime
             }
         }
 
-        matcher = datetimePattern22.matcher(trimmedVal);
+        matcher = DATETIME_PATTERN_22.matcher(trimmedVal);
         if (matcher.matches())
         {
             int a = Integer.parseInt(matcher.group(1));
@@ -716,7 +716,7 @@ class DateTimeImpl implements DateTime
         }
         if (Character.isDigit(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern23.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_23.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -780,7 +780,7 @@ class DateTimeImpl implements DateTime
         }
         else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern24.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_24.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -839,7 +839,7 @@ class DateTimeImpl implements DateTime
     private int matchDTToMilli(String value)
     {
         int ret = CodecReturnCodes.SUCCESS;
-        matcher = datetimePattern1.matcher(trimmedVal);
+        matcher = DATETIME_PATTERN_1.matcher(trimmedVal);
         if (matcher.matches())
         {
             int a = Integer.parseInt(matcher.group(1));
@@ -905,7 +905,7 @@ class DateTimeImpl implements DateTime
 
         if (Character.isDigit(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern2.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_2.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -971,7 +971,7 @@ class DateTimeImpl implements DateTime
         }
         else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern3.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_3.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -1023,7 +1023,7 @@ class DateTimeImpl implements DateTime
             }
         }
 
-        matcher = datetimePattern4.matcher(trimmedVal);
+        matcher = DATETIME_PATTERN_4.matcher(trimmedVal);
         if (matcher.matches())
         {
             int a = Integer.parseInt(matcher.group(1));
@@ -1088,7 +1088,7 @@ class DateTimeImpl implements DateTime
         }
         if (Character.isDigit(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern5.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_5.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -1154,7 +1154,7 @@ class DateTimeImpl implements DateTime
         }
         else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern6.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_6.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -1215,7 +1215,7 @@ class DateTimeImpl implements DateTime
     private int matchDTToMicro(String value)
     {
         int ret = CodecReturnCodes.SUCCESS;
-        matcher = datetimePattern13.matcher(trimmedVal);
+        matcher = DATETIME_PATTERN_13.matcher(trimmedVal);
         if (matcher.matches())
         {
             int a = Integer.parseInt(matcher.group(1));
@@ -1283,7 +1283,7 @@ class DateTimeImpl implements DateTime
 
         if (Character.isDigit(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern14.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_14.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -1351,7 +1351,7 @@ class DateTimeImpl implements DateTime
         }
         else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern15.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_15.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -1405,7 +1405,7 @@ class DateTimeImpl implements DateTime
             }
         }
 
-        matcher = datetimePattern16.matcher(trimmedVal);
+        matcher = DATETIME_PATTERN_16.matcher(trimmedVal);
         if (matcher.matches())
         {
             int a = Integer.parseInt(matcher.group(1));
@@ -1472,7 +1472,7 @@ class DateTimeImpl implements DateTime
         }
         if (Character.isDigit(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern17.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_17.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -1540,7 +1540,7 @@ class DateTimeImpl implements DateTime
         }
         else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern18.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_18.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -1604,7 +1604,7 @@ class DateTimeImpl implements DateTime
     {
         int ret = CodecReturnCodes.SUCCESS;
 
-        matcher = datetimePattern7.matcher(trimmedVal);
+        matcher = DATETIME_PATTERN_7.matcher(trimmedVal);
         if (matcher.matches())
         {
             int a = Integer.parseInt(matcher.group(1));
@@ -1674,7 +1674,7 @@ class DateTimeImpl implements DateTime
 
         if (Character.isDigit(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern8.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_8.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -1744,7 +1744,7 @@ class DateTimeImpl implements DateTime
         }
         else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern9.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_9.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -1800,7 +1800,7 @@ class DateTimeImpl implements DateTime
             }
         }
 
-        matcher = datetimePattern10.matcher(trimmedVal);
+        matcher = DATETIME_PATTERN_10.matcher(trimmedVal);
         if (matcher.matches())
         {
             int a = Integer.parseInt(matcher.group(1));
@@ -1869,7 +1869,7 @@ class DateTimeImpl implements DateTime
         }
         if (Character.isDigit(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern11.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_11.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -1939,7 +1939,7 @@ class DateTimeImpl implements DateTime
         }
         else if (Character.isUpperCase(trimmedVal.charAt(3)) || Character.isLowerCase(trimmedVal.charAt(3)))
         {
-            matcher = datetimePattern12.matcher(trimmedVal);
+            matcher = DATETIME_PATTERN_12.matcher(trimmedVal);
             if (matcher.matches())
             {
                 int a = Integer.parseInt(matcher.group(1));
@@ -2084,7 +2084,7 @@ class DateTimeImpl implements DateTime
 
         for (i = 0; i < 12; i++)
         {
-            if (months[i].equalsIgnoreCase(monthStr))
+            if (MONTHS_EN[i].equalsIgnoreCase(monthStr))
             {
                 month = i + 1;
                 break;

--- a/Java/Eta/Core/src/main/java/com/thomsonreuters/upa/codec/TimeImpl.java
+++ b/Java/Eta/Core/src/main/java/com/thomsonreuters/upa/codec/TimeImpl.java
@@ -26,16 +26,16 @@ class TimeImpl implements Time
     // for value(String) method
     private String trimmedVal;
     private Matcher matcher;
-    private Pattern timePattern1 = Pattern.compile("(\\d+):(\\d+):(\\d+):(\\d+)");
-    private Pattern timePattern2 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");
-    private Pattern timePattern3 = Pattern.compile("(\\d+):(\\d+):(\\d+)");
-    private Pattern timePattern4 = Pattern.compile("(\\d+):(\\d+)");
-    private Pattern timePattern5 = Pattern.compile("(\\d+):(\\d+):(\\d+):(\\d+):(\\d+)");
-    private Pattern timePattern6 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");
-    private Pattern timePattern7 = Pattern.compile("(\\d+):(\\d+):(\\d+):(\\d+):(\\d+):(\\d+)");
-    private Pattern timePattern8 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");
-    private Pattern timePattern9 = Pattern.compile("(\\d+):(\\d+):(\\d+)\\.(\\d+)"); // ISO8601 hh:mm:ss.nnnnnnnnn e.g. 08:37:48.009216350
-    private Pattern timePattern10 = Pattern.compile("(\\d+):(\\d+):(\\d+),(\\d+)"); // ISO8601 hh:mm:ss.nnnnnnnnn e.g. 08:37:48,009216350
+    private static final Pattern TIME_PATTERN_1 = Pattern.compile("(\\d+):(\\d+):(\\d+):(\\d+)");
+    private static final Pattern TIME_PATTERN_2 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");
+    private static final Pattern TIME_PATTERN_3 = Pattern.compile("(\\d+):(\\d+):(\\d+)");
+    private static final Pattern TIME_PATTERN_4 = Pattern.compile("(\\d+):(\\d+)");
+    private static final Pattern TIME_PATTERN_5 = Pattern.compile("(\\d+):(\\d+):(\\d+):(\\d+):(\\d+)");
+    private static final Pattern TIME_PATTERN_6 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");
+    private static final Pattern TIME_PATTERN_7 = Pattern.compile("(\\d+):(\\d+):(\\d+):(\\d+):(\\d+):(\\d+)");
+    private static final Pattern TIME_PATTERN_8 = Pattern.compile("(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)\\s(\\d+)");
+    private static final Pattern TIME_PATTERN_9 = Pattern.compile("(\\d+):(\\d+):(\\d+)\\.(\\d+)"); // ISO8601 hh:mm:ss.nnnnnnnnn e.g. 08:37:48.009216350
+    private static final Pattern TIME_PATTERN_10 = Pattern.compile("(\\d+):(\\d+):(\\d+),(\\d+)"); // ISO8601 hh:mm:ss.nnnnnnnnn e.g. 08:37:48,009216350
    
     @Override
     public void clear()
@@ -419,7 +419,7 @@ class TimeImpl implements Time
         		return CodecReturnCodes.INVALID_ARGUMENT;
 
         	// ISO8601 hh:mm:ss.nnnnnnnnn e.g. 08:37:48.009216350 
-        	matcher = timePattern9.matcher(trimmedVal);
+        	matcher = TIME_PATTERN_9.matcher(trimmedVal);
         	if (matcher.matches())
         	{
                 ret = hour(Integer.parseInt(matcher.group(1)));
@@ -436,7 +436,7 @@ class TimeImpl implements Time
         	}
         	
         	// ISO8601 hh:mm:ss.nnnnnnnnn e.g. 08:37:48,009216350
-        	matcher = timePattern10.matcher(trimmedVal);
+        	matcher = TIME_PATTERN_10.matcher(trimmedVal);
         	if (matcher.matches())
         	{
                 ret = hour(Integer.parseInt(matcher.group(1)));
@@ -452,7 +452,7 @@ class TimeImpl implements Time
         		return iso8601FractionalStingTimeToTime(matcher.group(4));
         	}        	
             // hh:mm:ss:lll:uuu:nnn
-            matcher = timePattern7.matcher(trimmedVal);
+            matcher = TIME_PATTERN_7.matcher(trimmedVal);
             if (matcher.matches())
             {
                 ret = hour(Integer.parseInt(matcher.group(1)));
@@ -478,7 +478,7 @@ class TimeImpl implements Time
             }
 
             // hh mm ss lll uuu nnn
-            matcher = timePattern8.matcher(trimmedVal);
+            matcher = TIME_PATTERN_8.matcher(trimmedVal);
             if (matcher.matches())
             {
                 ret = hour(Integer.parseInt(matcher.group(1)));
@@ -504,7 +504,7 @@ class TimeImpl implements Time
             }
 
             // hh:mm:ss:lll:uuu
-            matcher = timePattern5.matcher(trimmedVal);
+            matcher = TIME_PATTERN_5.matcher(trimmedVal);
             if (matcher.matches())
             {
                 ret = hour(Integer.parseInt(matcher.group(1)));
@@ -527,7 +527,7 @@ class TimeImpl implements Time
             }
 
             // hh mm ss lll uuu nnn
-            matcher = timePattern6.matcher(trimmedVal);
+            matcher = TIME_PATTERN_6.matcher(trimmedVal);
             if (matcher.matches())
             {
                 ret = hour(Integer.parseInt(matcher.group(1)));
@@ -549,7 +549,7 @@ class TimeImpl implements Time
                 return CodecReturnCodes.SUCCESS;
             }
 
-            matcher = timePattern1.matcher(trimmedVal);
+            matcher = TIME_PATTERN_1.matcher(trimmedVal);
             if (matcher.matches())
             {
                 ret = hour(Integer.parseInt(matcher.group(1)));
@@ -568,7 +568,7 @@ class TimeImpl implements Time
                 return CodecReturnCodes.SUCCESS;
             }
 
-            matcher = timePattern2.matcher(trimmedVal);
+            matcher = TIME_PATTERN_2.matcher(trimmedVal);
             if (matcher.matches())
             {
                 ret = hour(Integer.parseInt(matcher.group(1)));
@@ -587,7 +587,7 @@ class TimeImpl implements Time
                 return CodecReturnCodes.SUCCESS;
             }
 
-            matcher = timePattern3.matcher(trimmedVal);
+            matcher = TIME_PATTERN_3.matcher(trimmedVal);
             if (matcher.matches())
             {
                 ret = hour(Integer.parseInt(matcher.group(1)));
@@ -603,7 +603,7 @@ class TimeImpl implements Time
                 return CodecReturnCodes.SUCCESS;
             }
 
-            matcher = timePattern4.matcher(trimmedVal);
+            matcher = TIME_PATTERN_4.matcher(trimmedVal);
             if (matcher.matches())
             {
                 ret = hour(Integer.parseInt(matcher.group(1)));


### PR DESCRIPTION
- Fixed a bunch of regexp [Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html)s that were created for each and every creation of the object, rather than just once (they were not static, but could have been). This created unnecessary computational and memory overhead. Pattern class is immutable so safe to share between threads.

- Fixed the array with English 3-letter month names which wasn't static and was furthermore defined in two classes (duplicate). It has now been centralized to `DateImpl` class and made static final. 